### PR TITLE
BOLT 02: opt-in dual-funding

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -292,3 +292,4 @@ SRV
 TTL
 URI
 cli
+malleated

--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -29,6 +29,9 @@ def guess_alignment(message, name, sizestr):
     if message == 'node_announcement' and name == 'alias':
         return 1
 
+    if message == 'accept_channel' and name == 'len':
+        return 1
+
     if 'signature' in name:
         return 1
 


### PR DESCRIPTION
The goal of this PR is to enable dual-funding, which we believe is an important feature because it lets nodes create channels that can be used to pay on both sides from the start, which improves user experience. Also, from a routing point of view it may be easier to bootstrap a network of balanced channels.
 
The protocol has been changed as little as possible and existing messages are reused, so even though dual-funding was supposed to be a 1.1 feature it may makes its way into 1.0.
 
This is partially inspired by what lnd was doing some time ago (maybe it was a feature branch or an option ?) but I’ve chosen to keep the number of messages to a minimum and use serialized tx instead of breaking them up into specific fields: some of the opening messages have been modified to include serialized transactions. This is not optimal, but I believe that it is not significant since these messages will only be exchanged once, and all implementations include tools that understand the bitcoin protocol so we don't have to reimplement serialization of tx inputs, outputs, …
 
To minimize the number of messages, the funder now provides a partial funding tx in their open message. The fundee will then be able to add their own inputs and change output to the funding tx, as well as the multisig funding output, compute the txid of the funding tx, and compute a signature for the funder’s commit tx.
 
Another option would be to keep the messages that we have now and add new specific messages for the dual funding process, which would create 2 clearly identified workflows for opening channels (with or without dual funding).
 
 
The gist of it is:
 
A --- open-channel ----> B 
// open_channel includes a partial funding tx with A's inputs and change outputs
 
A <-- accept_channel --- B 
// accept channel includes a complete but unsigned funding tx, as well as A's commit sig
// A and B now have an unsigned funding tx that cannot be malleated
 
A --- funding_created --> B 
// funding_created includes B's commit sig
// A and B now have signed commit txs
 
A <-- funding_signed --- B 
// funding signed includes witness scripts for every input added by B
// A has now a fully signed funding tx
 
On the plus side:
* users can start with channels that can be used to pay on both sides
 
On the minus side:
* opening messages are larger than they could be
* funder must create and send a partial funding tx in the first message
* fees are still paid by the funder, even if the other side also funds the channel 
