### PR TITLE
make: add document generation with pandoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pdf
+*.man
+*.mobi
+*.epub

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,26 @@
 FILENAME=lightning
 TITLE=title.txt
 
-DEF_TARGETS=lightning.epub lightning.pdf
-TARGETS=$(DEF_TARGETS) lightning.mobi
+PANDOC_OPTS=-sS
+PANDOC_PDF_OPTS=$(PANDOC_OPTS) -V geometry:margin=1.5in
+
+DEF_TARGETS=$(FILENAME).epub $(FILENAME).pdf
+TARGETS=$(DEF_TARGETS) $(FILENAME).mobi $(FILENAME).man
 MDS=$(sort $(wildcard *-*.md))
 
 all: $(DEF_TARGETS)
 
-$(FILENAME).%: $(TITLE) $(MDS)
-	pandoc -S -o $@ $^
+man: $(FILENAME).man FAKE
+	@man ./$(FILENAME).man
+
+$(FILENAME).pdf: $(TITLE) $(MDS)
+	pandoc $(PANDOC_PDF_OPTS) -o $@ $^
+
+$(FILENAME).man: $(TITLE) $(MDS)
+	pandoc $(PANDOC_OPTS) -o $@ -t man $^
+
+$(FILENAME).epub: $(TITLE) $(MDS)
+	pandoc $(PANDOC_OPTS) -o $@ $^
 
 $(FILENAME).mobi: $(FILENAME).epub
 	ebook-convert $< $@
@@ -16,4 +28,4 @@ $(FILENAME).mobi: $(FILENAME).epub
 clean:
 	rm -f $(TARGETS)
 
-.PHONY: clean
+.PHONY: clean FAKE

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+FILENAME=lightning
+TITLE=title.txt
+
+DEF_TARGETS=lightning.epub lightning.pdf
+TARGETS=$(DEF_TARGETS) lightning.mobi
+MDS=$(sort $(wildcard *-*.md))
+
+all: $(DEF_TARGETS)
+
+$(FILENAME).%: $(TITLE) $(MDS)
+	pandoc -S -o $@ $^
+
+$(FILENAME).mobi: $(FILENAME).epub
+	ebook-convert $< $@
+
+clean:
+	rm -f $(TARGETS)
+
+.PHONY: clean

--- a/title.txt
+++ b/title.txt
@@ -1,0 +1,6 @@
+---
+title: Lightning Network In-Progress Specifications
+author: Rusty Russell et al.
+rights: Attribution 4.0 International (CC BY 4.0)
+language: en-US
+---


### PR DESCRIPTION
This adds a Makefile for generating pdf, epub and mobi files.

The default targets are pdf and epub, since they are the most common and
only requires one dependency, pandoc. Generation of mobi files requires
calibre.

I'm not sure if this is an appropriate PR for this repo, but I found it useful to have in case of anyone else was interested in generating ebooks for reading on their kindles, etc. Otherwise feel free to close :eyes: 