### PR TITLE
BOLT 07: delay announcement_signatures by max(6, min_depth) confs

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -69,8 +69,9 @@ of the block at height 539268.
 A node:
   - if the `open_channel` message has the `announce_channel` bit set AND a `shutdown` message has not been sent:
     - MUST send the `announcement_signatures` message.
-      - MUST NOT send `announcement_signatures` messages until `funding_locked`
-      has been sent and received AND the funding transaction has at least six confirmations.
+      - SHOULD send `announcement_signatures` after the funding transaction has
+        `max(6, minimum_depth)` confirmations, where `minimum_depth` is the
+        value proposed by the fundee in `accept_channel`.
   - otherwise:
     - MUST NOT send the `announcement_signatures` message.
   - upon reconnection (once the above timing requirements have been met):


### PR DESCRIPTION
This PR modifies the sending requirements of `announcement_signatures` to wait `max(6, min_depth)` blocks before sending. The current reading says to wait for the `funding_locked` exchange and 6 confirmations, so this modification doesn't change the height at which the `announcement_signatures` should first be sent, but removes the stricter ordering requirements wrt `funding_locked` and (indirectly) `channel_reestablish`.

Note that the current wording is conflicting, as BOLT 2 say that BOLT 7 message retransmission is independent of BOLT 2 retransmission, though the current `announcement_signatures` retransmission has ordering requirements wrt to `funding_locked`.

The proposed fix here is to relax the ordering constraints on `announcement_signatures`, while still ensuring that `announcement_signatures` aren't transmitted grossly before the `funding_locked` message (e.g., the case where `min_depth >> 6`). This change is aimed at making the BOLTs more isolated, and reduce the coordination requirements between gossip and peer messages.

This change makes it easier for implementations to isolate critical forwarding functionality from non-critical processing of gossip traffic via isolated daemons or subsystems.

See prior discussion on #620 