### PR TITLE
BOLT04: Atomic Multi-path Payments [feature 30/31]

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -362,3 +362,11 @@ tlvs
 snprintf
 GitHub
 IRC
+preimages
+timelocks
+th
+atomicity
+adaptively
+preimages
+griefing
+decorrelation

--- a/09-features.md
+++ b/09-features.md
@@ -31,9 +31,10 @@ These flags may only be used in the `init` message:
 
 The following `globalfeatures` bits are currently assigned by this specification:
 
-| Bits | Name              | Description                                                        | Link                                  |
-|------|-------------------|--------------------------------------------------------------------|---------------------------------------|
-| 8/9  | `var_onion_optin` | This node requires/supports variable-length routing onion payloads | [Routing Onion Specification][bolt04] |
+| Bits  | Name              | Description                                                        | Link                                  |
+|-------|-------------------|--------------------------------------------------------------------|---------------------------------------|
+| 8/9   | `var_onion_optin` | This node requires/supports variable-length routing onion payloads | [Routing Onion Specification][bolt04] |
+| 12/13 | `option_amp`      | Payee supports AMP                                                 | [BOLT #4](04-onion-routing#atomic-multi-path-payments)
 
 
 ## Requirements


### PR DESCRIPTION
Hi all, decided to submit this draft concurrently with @rustyrussell's [Base AMP](#643) since there is likely a bit of overlap, and comments can likely be shared between the two. The structure of the proposal and requirements is based on #643 to make that process simpler. The chosen feature bits are just temporary.

## Background

This proposal outlines the requirements for Atomic Multi-path Payments originally outlined in @Roasbeef and I's [email to lightning-dev](https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-February/000993.html). The proposal has also been referred to as OG AMP, or Moon AMP due to the moon-math involved :)

The core of the proposal is mostly unchanged, though I will highlight some distinctions:
 - The Extra Onion Blob (EOB) concept has been ditched in favor of the variable-sized hop-payloads via #619
 - Termination is signaled via `total_msat` (as in [Base AMP](#643)) instead of a transmitting the number of shares. This is more flexible when sending partial payments adaptively, since the required number of partial payments may not be known upfront, while the total amount being paid should be known. Committing to the total amount being paid also eliminates weaknesses in zero-value invoices, or any scenario involving overpayment.
 - The 11-byte payment ID is replaced with a full 32-byte `set_id`
 - Various modifications in nomenclature

## Summary

One of the biggest distinctions (some would argue drawback) from [Base AMP](#643) is that the sender does not receive a preimage as a result of a successful payment. However, the lack of a "proof" of payment unlocks a range of novel features:
 - Partial Payment Decorrelation: each subpayment uses a different payment hash, offering stronger privacy from intermediaries
 - Concurrent-Safe Reusable Invoices: As a by-product of the sender generating the preimages and payment hashes, an invoice is no longer single use. The payer conveys to the payee which invoice is being settled by including the invoice's payment hash. All payments made to the invoice can be tracked as a single subscription or account, and each payment receives it's own unique `set_id`. Multiple, concurrent payments can be made to the same invoice and properly reconstructed using the enclosed `set_id`.
    - A subscription invoice might be generated as an invoice with the desired subscription amount, which will be verified each time the user pays.
    - An account invoice, e.g. a recurring invoice for funding an exchange, would use a zero-value invoice, allowing deposits (or withdrawals) of arbitrary amounts.
 - Spontaneous AMPs: More often discussed in the single-shot case, this describes users making payments to other nodes using just their public key (handwaves hop hints). However, AMP is really a generalization of the single-shot case, so we propose to merge these two concepts under a single, unified proposal. All of the tangential benefits of AMP are carried over to spontaneous single-shot payments (SSSP?), without introducing any additional code complexity.

## Open Questions

 - Some of the fields included in `option_amp` are to be included in other proposals as well. Should we reuse the `total_msat` field from `option_mpp`, which can make use of the truncated encoding? Similarly, the `set_id` is analogous to the proposal to generically include a nonce in all payments, should that be it's own record? The signaling of which feature you are attempting to use may be more complex, but it's RISC-ier in some sense.

Feedback appreciated!