### PR TITLE
Public key-based routing (Feature **NEEDS NUMBER***)

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -263,6 +263,9 @@ It is formatted according to the Type-Length-Value format defined in [BOLT #1](0
     2. data:
         * [`32*byte`:`payment_secret`]
         * [`tu64`:`total_msat`]
+    1. type: 10 (`pub_key`)
+    2. data:
+        * [`33*byte`:`pub_key`]
 
 ### Requirements
 
@@ -272,10 +275,16 @@ The writer:
   - For every node:
     - MUST include `amt_to_forward` and `outgoing_cltv_value`.
   - For every non-final node:
-    - MUST include `short_channel_id`
+    - If `option_pubkey_routing`:
+      - MUST NOT include `short_channel_id`
+      - MUST include `pub_key`
+    - If not `option_pubkey_routing`:
+      - MUST include `short_channel_id`
+      - MUST NOT include `pub_key`
     - MUST NOT include `payment_data`
   - For the final node:
     - MUST NOT include `short_channel_id`
+    - MUST NOT include `pub_key`
     - if the recipient provided `payment_secret`:
       - MUST include `payment_data`
       - MUST set `payment_secret` to the one provided
@@ -380,6 +389,8 @@ nodes A and B, the HTLC can be forwarded across any channel connecting A and B.
 Failure to adhere will result in the receiver being unable to decrypt the next
 hop in the onion packet.
 
+If `pub_key` is specified, forwarding can only be non-strict.
+
 ### Rationale
 
 In the event that two peers have multiple channels, the downstream node will be
@@ -399,7 +410,8 @@ A and B.
 
 Non-strict forwarding allows nodes to make use of private channels connecting
 them to the receiving node, even if the channel is not known in the public
-channel graph.
+channel graph. When `option_pubkey_routing` is used, no channel point information
+needs to be leaked through invoice route hints at all.
 
 ### Recommendation
 

--- a/09-features.md
+++ b/09-features.md
@@ -40,6 +40,7 @@ The Context column decodes as follows:
 | 18/19 | `option_support_large_channel`   | Can create large channels                                 | IN       |                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 | 20/21 | `option_anchor_outputs`          | Anchor outputs                                            | IN       | `option_static_remotekey` | [BOLT #3](03-transactions.md)         |
 | 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
+| 26/27 | `option_pubkey_routing`          | Public key routing                                        | IN9      | `var_onion_optin` | [BOLT #4](04-onion-routing.md#tlv-payload-format)         |
 
 ## Requirements
 

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -187,8 +187,10 @@ A writer:
     - MUST include at least one `r` field.
       - `r` field MUST contain one or more ordered entries, indicating the forward route from
       a public node to the final destination.
-        - Note: for each entry, the `pubkey` is the node ID of the start of the channel;
-        `short_channel_id` is the short channel ID field to identify the channel; and
+        - Note: for each entry, the `pubkey` is the node ID of the start of the channel.
+        `short_channel_id` is the short channel ID field to identify the channel. If the routing node
+        supports `option_pubkey_routing`, `short_channel_id` may be set to all zeroes to
+        keep the channel point information private.
         `fee_base_msat`, `fee_proportional_millionths`, and `cltv_expiry_delta` are as
         specified in [BOLT #7](07-routing-gossip.md#the-channel_update-message).
     - MAY include more than one `r` field to provide multiple routing options.


### PR DESCRIPTION
In today's Lightning Network, routes are described as a series of short channel ids. Routing nodes use these short channel ids to determine to which of its peers an htlc needs to be forwarded.

The advantage of short channel ids is that they are short - just 8 bytes.

A great downside is that a short channel id corresponds directly to a channel point on-chain. A channel point reveals the size of the channel and is thereby an indication of the amount of funds that are kept by the channel parties in their node hot wallets. Large hot wallets are an attractive target to hackers.

For public channels, this isn't an issue. To advertise a public channel, the channel point needs to be revealed anyway so that other node are able to verify the existence of the channel. 

For private channels it is different. Private channels are only disclosed in invoice route hints and don't need to be verified. The invoice is created and signed by the receiver and there is no reason to include a non-existing channel in there. Ideally the invoice does not contain channel points. Otherwise someone can request an invoice (or multiple invoices) from a service that accepts Lightning payments and inspect the route hints to gauge the service's node capacity.

This PR proposes a new routing mode based on full public keys instead of short channel ids. When nodes signal `option_pubkey_routing`, they'll also accept a public key in the tlv onion payload to control the outgoing direction of the htlc.

With this feature, receivers can strip the channel points of private channels from invoices for peers that support `option_pubkey_routing`. Senders need to construct pubkey tlv payloads for the final private leg towards the destination. This increases the payload size with an extra 25 bytes. But as this is only required for the last (or last few) hops, the reduction of the maximum route length isn't very significant.

Optionally the invoice format can be changed so that short channel ids can be omitted completely from route hints, saving 8 bytes per route hint.

Overall a relatively simple change that makes Lightning safer to use for network endpoints in particular.