### PR TITLE
BOLT 2: upgrade protocol on reestablish

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -255,6 +255,8 @@ Once authentication is complete, the first message reveals the features supporte
 
 [BOLT #9](09-features.md) specifies lists of features. Each feature is generally represented by 2 bits. The least-significant bit is numbered 0, which is _even_, and the next most significant bit is numbered 1, which is _odd_.  For historical reasons, features are divided into global and local feature bitmasks.
 
+We refer to a feature as *offered* if a peer set it in the `init` message for the current connection (as either even or odd), and *negotiated* if both peers offered it.
+
 The `features` field MUST be padded to bytes with 0s.
 
 1. type: 16 (`init`)

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1693,14 +1693,14 @@ fall back to the `option_data_loss_protect` behavior if
 
 ### Upgrading Channels
 
-Upgrading channels (e.g. enabling `option_static_remotekey` for a
+Upgrading channels (e.g. enabling `option_static_remotekey` or `option_anchors` for a
 channel where it was not negotiated originally) is possible at
 reconnection time if both implementations support it.
 
 For simplicity, upgrades are proposed by the original initiator of the
 channel, and can only occur on channels with no pending updates and no
 retransmissions on reconnection.  This can be achieved explicitly
-using the [quiescence protocol](#channel-quiescence).
+using the quiescence protocol, when implemented.
 
 In case of disconnection where one peer doesn't receive
 `channel_reestablish` it's possible that one peer will consider the
@@ -1710,7 +1710,7 @@ resolved: the channel cannot progress until both sides have received
 
 #### Requirements
 
-A node sending `channel_reestablish`, if it supports upgrading channels:
+A node sending `channel_reestablish`, if `option_upgradable` is negotiated:
   - MUST set `next_to_send` the commitment number of the next `commitment_signed` it expects to send.
   - if it initiated the channel:
     - MUST set `desired_channel_type` to the defined channel type it wants for the channel.
@@ -1719,7 +1719,7 @@ A node sending `channel_reestablish`, if it supports upgrading channels:
     - If it sets `upgradable_channel_type`:
       - MUST set it to a defined channel type it could change to.
 
-A node receiving `channel_reestablish`:
+A node receiving `channel_reestablish`, if `option_upgradable` is negotiated:
   - if it has to retransmit `commitment_signed` or `revoke_and_ack`:
     - MUST consider the channel type change failed.
   - if `next_to_send` is missing, or not equal to the `next_commitment_number` it sent:

--- a/09-features.md
+++ b/09-features.md
@@ -49,6 +49,7 @@ The Context column decodes as follows:
 | 46/47 | `option_scid_alias`               | Supply channel aliases for routing                        | IN       |                           | [BOLT #2][bolt02-channel-ready]                                       |
 | 48/49 | `option_payment_metadata`         | Payment metadata in tlv record                            | 9        |                           | [BOLT #11](11-payment-encoding.md#tagged-fields)                      |
 | 50/51 | `option_zeroconf`                 | Understands zeroconf channel types                        | IN       | `option_scid_alias`       | [BOLT #2][bolt02-channel-ready]                                       |
+| 58/59 | `option_upgradable`               | Understands upgrade protocol on reconnect                 | IN       |                           | [BOLT #2][bolt02-upgrading-channels]                                   |
 
 ## Definitions
 
@@ -101,6 +102,7 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 
 [bolt02-retransmit]: 02-peer-protocol.md#message-retransmission
 [bolt02-open]: 02-peer-protocol.md#the-open_channel-message
+[bolt02-upgrading-channels]: 02-peer-protocol.md#upgrading-channels
 [bolt03-htlc-tx]: 03-transactions.md#htlc-timeout-and-htlc-success-transactions
 [bolt02-shutdown]: 02-peer-protocol.md#closing-initiation-shutdown
 [bolt02-channel-ready]: 02-peer-protocol.md#the-channel_ready-message


### PR DESCRIPTION
This is the simplest upgrade mechanism I could come up with.  It's ready for option_anchors_zero_fee_htlc_tx, too.

Note the reason it's on reconnect: whatever we do, we need to handle reconnect during an upgrade attempt, which meant some kind of fallback "where were we up to?" at that point.  Simplest to make that "fallback" technique the only technique.

And in practice we don't upgrade software without reconnecting anyway.

