### PR TITLE
anchors: follow up changes after initial zero fee anchors merge

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1314,7 +1314,7 @@ The sending node:
   next `commitment_signed` it expects to receive.
   - MUST set `next_revocation_number` to the commitment number of the
   next `revoke_and_ack` message it expects to receive.
-  - if `option_static_remotekey` or `option_anchors` applies to the commitment
+  - if `option_static_remotekey` applies to the commitment
     transaction:
     - MUST set `my_current_per_commitment_point` to a valid point.
   - otherwise:
@@ -1362,8 +1362,7 @@ A node:
       - SHOULD fail the channel.
 
  A receiving node:
-  - if `option_static_remotekey` or `option_anchors` applies to the commitment
-    transaction:
+  - if `option_static_remotekey` applies to the commitment transaction:
     - if `next_revocation_number` is greater than expected above, AND
     `your_last_per_commitment_secret` is correct for that
     `next_revocation_number` minus 1:

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -449,7 +449,7 @@ use `option_static_remotekey`, `option_anchor_outputs` or
 
 `option_anchors_zero_fee_htlc_tx` is considered superior to
 `option_anchor_outputs`, which again is considered superior to
-`option_static_remotekey`, and the superior one is is favored if more than one
+`option_static_remotekey`, and the superior one is favored if more than one
 is negotiated.
 
 ### The `funding_locked` Message

--- a/09-features.md
+++ b/09-features.md
@@ -39,7 +39,7 @@ The Context column decodes as follows:
 | 16/17 | `basic_mpp`                      | Node can receive basic multi-part payments                | IN9      | `payment_secret`  | [BOLT #4][bolt04-mpp]                 |
 | 18/19 | `option_support_large_channel`   | Can create large channels                                 | IN       |                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 | 20/21 | `option_anchor_outputs`          | Anchor outputs                                            | IN       | `option_static_remotekey` | [BOLT #3](03-transactions.md)         |
-| 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
+| 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       | `option_static_remotekey` | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
 | 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`              | IN       |                   | [BOLT #2][bolt02-shutdown]   |
 
 ## Definitions


### PR DESCRIPTION
Fixup changes:
  * features: make anchor zero fee explicitly dependent on static key
  * re-order section explaining new HTLC output trimming