### PR TITLE
Use warning message in quick close

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -661,7 +661,7 @@ The receiving node:
     - MAY close the connection.
   - if the message contains a `fee_range`:
     - if there is no overlap between that and its own `fee_range`:
-      - SHOULD fail the connection
+      - SHOULD send a warning
       - MUST fail the channel if it doesn't receive a satisfying `fee_range` after a reasonable amount of time
     - otherwise:
       - if it is the funder:


### PR DESCRIPTION
Once #834 have been accepted to the spec, we should use a warning in quick close instead of failing the connection.