### PR TITLE
Add payment metadata to payment request (feature 48)

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -263,6 +263,9 @@ It is formatted according to the Type-Length-Value format defined in [BOLT #1](0
     2. data:
         * [`32*byte`:`payment_secret`]
         * [`tu64`:`total_msat`]
+    1. type: 16 (`payment_metadata`)
+    2. data:
+        * [`...*byte`:`payment_metadata`]
 
 ### Requirements
 
@@ -280,6 +283,9 @@ The writer:
       - MUST include `payment_data`
       - MUST set `payment_secret` to the one provided
       - MUST set `total_msat` to the total amount it will send
+    - if the recipient provided `payment_metadata`:
+      - MUST include `payment_metadata` with every HTLC
+      - MUST not apply any limits to the size of payment_metadata except the limits implied by the fixed onion size
 
 The reader:
   - MUST return an error if `amt_to_forward` or `outgoing_cltv_value` are not present.
@@ -301,6 +307,9 @@ Note that `amt_to_forward` is the amount for this HTLC only: a
 ultimate sender that the rest of the payment will follow in succeeding
 HTLCs; we call these outstanding HTLCs which have the same preimage,
 an "HTLC set".
+
+`payment_metadata` is to be included in every payment part, so that
+invalid payment details can be detected as early as possible.
 
 #### Requirements
 
@@ -948,9 +957,9 @@ handling by the processing node.
    * [`u32`:`height`]
 
 The `payment_hash` is unknown to the final node, the `payment_secret` doesn't
-match the `payment_hash`, the amount for that `payment_hash` is incorrect or
+match the `payment_hash`, the amount for that `payment_hash` is incorrect,
 the CLTV expiry of the htlc is too close to the current block height for safe
-handling.
+handling or `payment_metadata` isn't present while it should be.
 
 The `htlc_msat` parameter is superfluous, but left in for backwards
 compatibility. The value of `htlc_msat` always matches the amount specified in

--- a/09-features.md
+++ b/09-features.md
@@ -42,6 +42,7 @@ The Context column decodes as follows:
 | 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
 | 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`              | IN       |                   | [BOLT #2][bolt02-shutdown]   |
 | 44/45 | `option_channel_type`            | Node supports the `channel_type` field in open/accept     | IN       |                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
+| 48/49 | `option_payment_metadata` | Payment metadata in tlv record | 9 | | [BOLT #11](11-payment-encoding.md#tagged-fields)
 
 ## Definitions
 


### PR DESCRIPTION
This PR adds a new field to bolt11 invoices for payment metadata. Senders are supposed to carry over this data to a tlv field to provide context for stateless invoice applications.

More background on stateless invoices: https://lists.linuxfoundation.org/pipermail/lightning-dev/2021-September/003236.html

_Please attach comments to the most appropriate line of the diff, so that discussions remain threaded and can eventually be resolved. We all know what PRs look like with too many top level comments._