### PR TITLE
Drop ping sending rate-limit suggestion

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -356,7 +356,6 @@ memory.
   - if it doesn't receive a corresponding `pong`:
     - MAY terminate the network connection,
       - and MUST NOT fail the channels in this case.
-  - SHOULD NOT send `ping` messages more often than once every 30 seconds.
 
 A node sending a `pong` message:
   - SHOULD set `ignored` to 0s.
@@ -364,7 +363,6 @@ A node sending a `pong` message:
  memory.
 
 A node receiving a `ping` message:
-  - SHOULD fail the channels if it has received significantly in excess of one `ping` per 30 seconds.
   - if `num_pong_bytes` is less than 65532:
     - MUST respond by sending a `pong` message, with `byteslen` equal to `num_pong_bytes`.
   - otherwise (`num_pong_bytes` is **not** less than 65532):


### PR DESCRIPTION
There's not a lot of reason to explicitly rate-limit ping messages
on the sending side, hosts on the internet can *always* send you
as much traffic as they want, its up to you whether you want to
talk back to them.

This seems to have been intended as a cutoff where nodes can skip
responding to pings below a certain rate, but in practice 30
seconds is much too long a time to learn that your peer has
disconnected.

We could reduce the threshold, but its not like this is the only
place in the spec where a peer can request a message response, and
that is unlikely to change, making it of highly dubious value.