### PR TITLE
Clarify and relax requirements on `channel_reestablish`

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1381,7 +1381,7 @@ A node:
     `your_last_per_commitment_secret` is correct for that
     `next_revocation_number` minus 1:
       - MUST NOT broadcast its commitment transaction.
-      - SHOULD fail the channel.
+      - SHOULD send an `error` to request the peer to fail the channel.
     - otherwise:
       - if `your_last_per_commitment_secret` does not match the expected values:
         - SHOULD fail the channel.
@@ -1390,7 +1390,7 @@ A node:
     `your_last_per_commitment_secret` is correct for that
     `next_revocation_number` minus 1:
       - MUST NOT broadcast its commitment transaction.
-      - SHOULD fail the channel.
+      - SHOULD send an `error` to request the peer to fail the channel.
       - SHOULD store `my_current_per_commitment_point` to retrieve funds
         should the sending node broadcast its commitment transaction on-chain.
     - otherwise (`your_last_per_commitment_secret` or `my_current_per_commitment_point`


### PR DESCRIPTION
The peer that is using an outdated commitment must not fail the channel itself, rather it should request the other peer to fail the channel.

Also, I think we could relax the requirements on the "up-to-date" side of the channel: if we detect that remote is using an outdated state, we could also stay idle and give remote a chance to fix its data? Maybe the node operator just accidentally started their node using a wrong directory. Current behavior is a bit trigger happy. Of course if remote sends an `error`, then we force-close.