### PR TITLE
Clarification how messages are referred to

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -9,6 +9,14 @@ The default TCP port is 9735. This corresponds to hexadecimal `0x2607`: the Unic
 
 All data fields are unsigned big-endian unless otherwise specified.
 
+Within this document messages are referred to with their `message_name` instead of their type. In particular they are usually not referred to with as `message_name` message but just as `message_name`. Thus within the document we write 
+
+> If a node receives / sends a `message_name`...
+
+instead of:
+
+> If a node receives / sends a `message_name` message...
+
 ## Table of Contents
 
   * [Connection Handling and Multiplexing](#connection-handling-and-multiplexing)


### PR DESCRIPTION
I added a clarification to BOLT 1 that explains that messages are usually referred to with their `message_name` and not as `message_name` message.

I was confused while reviewing #932 where @pm47 wrote: 

> - SHOULD send an `error` to request the peer to fail the channel.

I was looking where errors in BOLT 2 where defined and realized that `error` meant `error` message of type 17 in BOLT1. 

I checked in the text and realized that "message" is often dropped. 

However there are also 111 occurrences in the text where "message" is appended after `message_name` as can be found with:

```
grep "\` message" *md -c
00-introduction.md:0
01-messaging.md:17
02-peer-protocol.md:45
03-transactions.md:3
04-onion-routing.md:1
05-onchain.md:1
07-routing-gossip.md:37
08-transport.md:0
09-features.md:6
10-dns-bootstrap.md:0
11-payment-encoding.md:1
CONTRIBUTING.md:0
```


Since there are 111 occurrences of the opposite behavior I am not sure if this should be defined / unified. 
