### PR TITLE
Removed requirement to broadcast an outdated commitment transaction

### DIFF
--- a/05-onchain.md
+++ b/05-onchain.md
@@ -143,15 +143,14 @@ A node:
       sufficient fee:
         - SHOULD use this fee to perform a *mutual close*.
       - otherwise:
-      	- if the node knows or assumes its channel state is outdated it
-      	  -  MUST NOT broadcast its *last commitment transaction*. 
-      	  -  SHOULD send an `error`.
+      	- if the node knows or assumes its channel state is outdated:
+      	  - MUST NOT broadcast its *last commitment transaction*.
         - otherwise:
           - MUST broadcast the *last commitment transaction*, for which it has a
-        signature, to perform a *unilateral close*.
-          - MUST spend any `to_local_anchor` output, providing sufficient fees as incentive to include the commitment transaction in a block
-        Special care must be taken when spending to a third-party, because this re-introduces the vulnerability that was
-        addressed by adding the CSV delay to the non-anchor outputs.
+          signature, to perform a *unilateral close*.
+          - MUST spend any `to_local_anchor` output, providing sufficient fees as incentive to include the commitment transaction in a block.
+          Special care must be taken when spending to a third-party, because this re-introduces the vulnerability that was
+          addressed by adding the CSV delay to the non-anchor outputs.
           - SHOULD use [replace-by-fee](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) or other mechanism on the spending transaction if it proves insufficient for timely inclusion in a block.
 
 ## Rationale

--- a/05-onchain.md
+++ b/05-onchain.md
@@ -143,12 +143,16 @@ A node:
       sufficient fee:
         - SHOULD use this fee to perform a *mutual close*.
       - otherwise:
-        - MUST use the *last commitment transaction*, for which it has a
+      	- if the node knows or assumes its channel state is outdated it
+      	  -  MUST NOT broadcast its *last commitment transaction*. 
+      	  -  SHOULD send an `error`.
+        - otherwise:
+          - MUST broadcast the *last commitment transaction*, for which it has a
         signature, to perform a *unilateral close*.
-      - MUST spend any `to_local_anchor` output, providing sufficient fees as incentive to include the commitment transaction in a block
+          - MUST spend any `to_local_anchor` output, providing sufficient fees as incentive to include the commitment transaction in a block
         Special care must be taken when spending to a third-party, because this re-introduces the vulnerability that was
         addressed by adding the CSV delay to the non-anchor outputs.
-	    - SHOULD use [replace-by-fee](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) or other mechanism on the spending transaction if it proves insufficient for timely inclusion in a block.
+          - SHOULD use [replace-by-fee](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) or other mechanism on the spending transaction if it proves insufficient for timely inclusion in a block.
 
 ## Rationale
 


### PR DESCRIPTION
Following the discussion at #932 and looking at the proposal of #834 I thought it might be good to clarify in BOLT 5 when a node MUST NOT (potentially SHOULD NOT) broadcast its own commitment transaction when failing the channel. 

If a node has to fail a channel but knows that its latest commitment transaction is outdated it should not be required to send it but rather wait for the peer to unilaterally close the channel. 

The proposed solution is not so clean because it might produce a deadlock in which two peers assume they have outdated state and send `error` back and forth without actually force closing. Maybe in such a scenario we could create a protocol that mutually closes with split balance? 

Also replaced the word use with broadcast as it seems more accurate.