### PR TITLE
accounting: round to nearest whole satoshi for balances, not down

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -101,8 +101,10 @@ Otherwise, the required minimum timeout on HTLCs is lengthened by this delay, ca
 
 The amounts for the `to_local` and `to_remote` outputs MUST be rounded
 to the nearest satoshi. Any amount less than 500msat is rounded down;
-any amount greater than 499msat is rounded up. This minimizes loss to fees
-over the lifetime of a node.
+any amount greater than 500msat is rounded up. This minimizes loss to fees
+over the lifetime of a node. If the outputs are 500msats,
+the opener's `to_local`/`to_remote` is rounded up; with the corresponding peer's
+output rounding down.
 
 The amounts for each HTLC output MUST be rounded *down* to whole satoshis. If this amount, minus the fees for the HTLC transaction, is less than the `dust_limit_satoshis` set by the owner of the commitment transaction, the output MUST NOT be produced (thus the funds add to fees).
 
@@ -392,7 +394,9 @@ There will be at least one output, if the funding amount is greater
 than twice `dust_limit_satoshis`.
 
 Output amounts are rounded to the nearest whole satoshi. Any amount less
-than 500msat is rounded down; any amount greater than 499msat is rounded up.
+than 500msat is rounded down; any amount greater than 500msat is rounded up.
+In the case that both outputs are 500msat, the opener's output is rounded up;
+with the corresponding peer's output rounded down.
 
 This ensures that over the lifetime of a node, the number of satoshis
 a node earns/spends will be approximately accurate.

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -99,7 +99,12 @@ To allow an opportunity for penalty transactions, in case of a revoked commitmen
 The reason for the separate transaction stage for HTLC outputs is so that HTLCs can timeout or be fulfilled even though they are within the `to_self_delay` delay.
 Otherwise, the required minimum timeout on HTLCs is lengthened by this delay, causing longer timeouts for HTLCs traversing the network.
 
-The amounts for each output MUST be rounded down to whole satoshis. If this amount, minus the fees for the HTLC transaction, is less than the `dust_limit_satoshis` set by the owner of the commitment transaction, the output MUST NOT be produced (thus the funds add to fees).
+The amounts for the `to_local` and `to_remote` outputs MUST be rounded
+to the nearest satoshi. Any amount less than 500msat is rounded down;
+any amount greater than 499msat is rounded up. This minimizes loss to fees
+over the lifetime of a node.
+
+The amounts for each HTLC output MUST be rounded *down* to whole satoshis. If this amount, minus the fees for the HTLC transaction, is less than the `dust_limit_satoshis` set by the owner of the commitment transaction, the output MUST NOT be produced (thus the funds add to fees).
 
 #### `to_local` Output
 
@@ -363,7 +368,7 @@ Note that there are two possible variants for each node.
 ### Requirements
 
 Each node offering a signature:
-  - MUST round each output down to whole satoshis.
+  - MUST round each output to the nearest whole satoshi.
   - MUST subtract the fee given by `fee_satoshis` from the output to the funder.
   - MUST remove any output below its own `dust_limit_satoshis`.
   - MAY eliminate its own output.
@@ -385,6 +390,12 @@ has been used.
 
 There will be at least one output, if the funding amount is greater
 than twice `dust_limit_satoshis`.
+
+Output amounts are rounded to the nearest whole satoshi. Any amount less
+than 500msat is rounded down; any amount greater than 499msat is rounded up.
+
+This ensures that over the lifetime of a node, the number of satoshis
+a node earns/spends will be approximately accurate.
 
 ## Fees
 


### PR DESCRIPTION
This is really more of a suggestion/draft than an entirely serious proposal. 

The update mechanism is missing from this PR and while it has merits in a very 'gross' sense, there's not really a rush or reason to change the way that outputs are calculated for close/commitment txs any time soon.

Rather this might be a change that's useful to wrap up into a broader protocol change (such as a move to PTLCs) which also impacts the commitment tx protocol; or a move to an 'interactive close' which impacts the close tx.

Also, this is probably much more important for the close tx than the unilateral case, as 1) unilaterals are usually ridiculously expensive in fees anyway, relatively speaking, and 2) are expected to be less frequent than mutual closes.

---


Over the lifetime of a node, rounding every msat balance down (adding to
fees) is a net loss of funds from the network to the miners.

To make things a bit more even, instead we can round to the nearest
satoshi for every peer balance output (on close txs and the
to_local/to_remote balances).

It gets a bit more complicated with HTLC output balances as there is no
'inherent yin/yang' relationship btw the htlc outputs; in other words
you may round up multiple times instead of one rounding up, the other
rounding down, which ends up with bad math.

Consider the following.

You have a 5000msats starting balance.

You add 2 htlcs of 750msats.

Here's what the balances would be if maintained in msats:

5000 - 1500 = 3500 to_local
               750 htlc_1
               750 htlc_2

With the applied rounding rule (round up if over 499), here's what
the following outputs would be:

4sat to_local
1sat htlc_1
1sat htlc_2

4 + 1 + 1 = 6, which is greater than the 5 sats we started with.

So to make this ok, the HTLCs are *always* rounded down, which means
that if the unilateral close they're in ever goes to chain,
there's a good chance you're down a fraction of a satoshi but those
won't be the only satoshis you're out if you go to chain with HTLCs
because recovering those funds onchain has a fee cost of generally
greater than a satoshi etc.