### PR TITLE
Echo `channel_type` in `accept_channel`

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -348,8 +348,8 @@ The sender:
 avoid double-spending of the funding transaction.
   - MUST set `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis` from the `open_channel` message.
   - MUST set `dust_limit_satoshis` less than or equal to `channel_reserve_satoshis` from the `open_channel` message.
-  - if it sets `channel_type`:
-    - MUST set it to the `channel_type` from `open_channel`
+  - if `option_channel_type` was negotiated:
+    - MUST set `channel_type` to the `channel_type` from `open_channel`
 
 The receiver:
   - if `minimum_depth` is unreasonably large:
@@ -360,6 +360,8 @@ The receiver:
     - MUST reject the channel.
   - if `channel_type` is set, and `channel_type` was set in `open_channel`, and they are not equal types:
     - MUST reject the channel.
+  - if `option_channel_type` was negotiated but the message doesn't include a `channel_type`:
+    - MAY reject the channel.
 
 Other fields have the same requirements as their counterparts in `open_channel`.
 


### PR DESCRIPTION
One argument for adding a feature bit for channel types was to make things more explicit and remove ambiguity (the other main argument was to be able to filter out peers that don't support this feature).

When sending `open_channel`, we require funders to include a `channel_type`, so it would make sense to require fundees to echo that `channel_type` back to explicitly confirm that they're ok with this particular `channel_type`.

This is the current behavior of eclair, please let me know if other implementations are doing it differently, and if you think this additional requirement shouldn't be added.