### PR TITLE
BOLT 1: introduce port convention for different network

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -5,12 +5,13 @@
 This protocol assumes an underlying authenticated and ordered transport mechanism that takes care of framing individual messages.
 [BOLT #8](08-transport.md) specifies the canonical transport layer used in Lightning, though it can be replaced by any transport that fulfills the above guarantees.
 
-The default TCP port depending from the network used. The most common networks are:
+The default TCP port depends on the network used. The most common networks are:
 
 - Bitcoin mainet with port number 9735 or the corresponding hexadecimal `0x2607`;
-- Bitcoin testnet with port number 19735 (`0x4D17`).
+- Bitcoin testnet with port number 19735 (`0x4D17`);
+- Bitcoin signet with port number 39735 (`0xF87`).
 
-The Unicode code point for LIGHTNING <sup>[1](#reference-1)</sup>, and the port convention try to follow the Bitcoin 0.22 convention.
+The Unicode code point for LIGHTNING <sup>[1](#reference-1)</sup>, and the port convention try to follow the Bitcoin Core convention.
 
 All data fields are unsigned big-endian unless otherwise specified.
 

--- a/01-messaging.md
+++ b/01-messaging.md
@@ -5,7 +5,12 @@
 This protocol assumes an underlying authenticated and ordered transport mechanism that takes care of framing individual messages.
 [BOLT #8](08-transport.md) specifies the canonical transport layer used in Lightning, though it can be replaced by any transport that fulfills the above guarantees.
 
-The default TCP port is 9735. This corresponds to hexadecimal `0x2607`: the Unicode code point for LIGHTNING.<sup>[1](#reference-1)</sup>
+The default TCP port depending from the network used. The most common networks are:
+
+- Bitcoin mainet with port number 9735 or the corresponding hexadecimal `0x2607`;
+- Bitcoin testnet with port number 19735 (`0x4D17`).
+
+The Unicode code point for LIGHTNING <sup>[1](#reference-1)</sup>, and the port convention try to follow the Bitcoin 0.22 convention.
 
 All data fields are unsigned big-endian unless otherwise specified.
 


### PR DESCRIPTION
This is an opinionate change proposed where there are reasons to have a default behavior for different networks, but there are also good reasons to have not this behavior.

I found the PR on Bitcoin core https://github.com/bitcoin/bitcoin/pull/23306 very good to have a good summary of pros and cons.

In addition, I think having a default port for different networks on lightning is a good thing to have because introducing some way to detect which network a lightning node is exposing with a particular URL composed by `node_id@ip:port`

We introduce a default behavior on c-lighting with the PR https://github.com/ElementsProject/lightning/pull/4900

P.S: As plus we have already a default port for Bitcoin maintet.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>