### PR TITLE
BOLT 2: forget the check about `update_*` messages, and check what must not happens during `shutdown`

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -405,7 +405,7 @@ The sender:
 The recipient:
   - if `signature` is incorrect OR non-compliant with LOW-S-standard rule<sup>[LOWS](https://github.com/bitcoin/bitcoin/pull/6769)</sup>:
     - MUST send a `warning` and close the connection, or send an
-      `error` and fail the channel.
+     `error` and fail the channel.
 
 #### Rationale
 
@@ -575,7 +575,8 @@ Closing happens in two stages:
         |       |<-(2)-----  shutdown  --------|       |
         |       |                              |       |
         |       | <complete all pending HTLCs> |       |
-        |   A   |                 ...          |   B   |
+        |       |    <must not add HTLCs>      |       |
+        |   A   |              ...             |   B   |
         |       |                              |       |
         |       |--(3)-- closing_signed  F1--->|       |
         |       |<-(4)-- closing_signed  F2----|       |
@@ -612,7 +613,6 @@ A sending node:
   - if it sent a non-zero-length `shutdown_scriptpubkey` in `open_channel` or `accept_channel`:
     - MUST send the same value in `scriptpubkey`.
   - MUST set `scriptpubkey` in one of the following forms:
-
     1. `OP_0` `20` 20-bytes (version 0 pay to witness pubkey hash), OR
     2. `OP_0` `32` 32-bytes (version 0 pay to witness script hash), OR
     3. if (and only if) `option_shutdown_anysegwit` is negotiated:


### PR DESCRIPTION
The rationale around this PR that is a simplification of #970  is that a node should not care about what it receives but only about what it must not receive. [Just to quote](https://github.com/lightning/bolts/pull/970/files#r840897665) @TheBlueMatt 

The actual Close Channel spec tell us exactly when we need to fail, we need just to remove the confusing part related to the `update_*` messages

So, the concept proposed is to use a black list of messages that a node should never receive during a shutdown, and the actual status the black list contains only is just an `add_htlc`.

lnprototest reference implementation: https://github.com/rustyrussell/lnprototest/pull/37