### PR TITLE
BOLT 2: allow multiple shutdown message from the sender side.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -544,6 +544,7 @@ A sending node:
   - MAY send a `shutdown` before a `funding_locked`, i.e. before the funding transaction has reached `minimum_depth`.
   - if there are updates pending on the receiving node's commitment transaction:
     - MUST NOT send a `shutdown`.
+  - MAY send multiple `shutdown` message, (but what happens if in the two shutdown message we insert different script? We need to accept only the last one sent?).
   - MUST NOT send an `update_add_htlc` after a `shutdown`.
   - if no HTLCs remain in either commitment transaction:
     - MUST NOT send any `update` message after a `shutdown`.
@@ -570,6 +571,7 @@ A receiving node:
   - if both nodes advertised the `option_upfront_shutdown_script` feature, and the receiving node received a non-zero-length `shutdown_scriptpubkey` in `open_channel` or `accept_channel`, and that `shutdown_scriptpubkey` is not equal to `scriptpubkey`:
     - MAY send a `warning`.
     - MUST fail the connection.
+  - MUST allow multiple `shutdown` messages from the sender.
 
 #### Rationale
 


### PR DESCRIPTION
This is something that I'm reasoning about during my lnprototest work, and maybe opening a PR gives me more opportunities to get feedback.

What happens if, during a Close Channel operation, the sender sent multiple shutdowns? 

At this moment, the spec doesn't tell anything about this case, but I think this is information to add. In my opinion, we need to allow multiple shutdown message from the sender (maybe after a timeout if we have no answer back), but in this case, there is some problem to resolve:

1. What do we need to do if the sender set the different `scriptpubkey` in the message? accept any of the `scriptpubkey` sent? or accept only the last one? In the last case, we can have more control over what we are doing but we can fall into a loop if the received is slow to answer again.
2. Do We need to set limits to the "multiple" message?

Think that this may introduce a complicated state machine in the spec, which I want to avoid!
