### PR TITLE
BOLT 2: disallow sending multiple `shutdown` msg

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -546,6 +546,7 @@ A sending node:
   - MAY send a `shutdown` before a `funding_locked`, i.e. before the funding transaction has reached `minimum_depth`.
   - if there are updates pending on the receiving node's commitment transaction:
     - MUST NOT send a `shutdown`.
+  - MUST NOT send multiple `shutdown` messages.
   - MUST NOT send an `update_add_htlc` after a `shutdown`.
   - if no HTLCs remain in either commitment transaction:
     - MUST NOT send any `update` message after a `shutdown`.


### PR DESCRIPTION
This is a second proposal different from https://github.com/lightning/bolts/pull/976 where it is not allowed to send multiple shutdown messages from the receiver viewpoint.

The rationale for this is to avoid bad cases like the following one that is permitted by the spec

```
     ____________________________________________
    | sender -> shutdown(script_one) -> receiver |
    | sender -> shutdown(script_two) -> receiver |
    | sender <- shutdown(script_one) <- receiver |
     --------------------------------------------
```
