### PR TITLE
BOLT 1: make remote_addr definition machine readable.

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -264,10 +264,9 @@ The `features` field MUST be padded to bytes with 0s.
     1. type: 1 (`networks`)
     2. data:
         * [`...*chain_hash`:`chains`]
-
     1. type: 3 (`remote_addr`)
     2. data:
-        * `address descriptor`  (1 byte type and data, see BOLT 7)
+        * [`...*byte`:`data`]
 
 The optional `networks` indicates the chains the node is interested in.
 The optional `remote_addr` can be used to circumvent NAT issues.
@@ -284,7 +283,9 @@ The sending node:
   - SHOULD set `remote_addr` to reflect the remote IP address (and port) of an
     incoming connection, if the node is the receiver and the connection was done
     via IP.
-  - SHOULD NOT set private addresses as `remote_addr`.
+  - if it sets `remote_addr`:
+    - MUST set it to a valid `address descriptor` (1 byte type and data) as described in [BOLT 7](07-routing-gossip.md#the-node_announcement-message).
+    - SHOULD NOT set private addresses as `remote_addr`.
 
 The receiving node:
   - MUST wait to receive `init` before sending any other messages.
@@ -298,7 +299,7 @@ The receiving node:
     - MAY close the connection.
   - if the feature vector does not set all known, transitive dependencies:
     - MUST close the connection.
-  - MAY use the `remote_addr` to update its `node_annoucement`
+  - MAY use the `remote_addr` to update its `node_announcement`
 
 #### Rationale
 


### PR DESCRIPTION
It had a blank line and invalid format for tools/extract-formats.py.  This meant that the python package omitted it!

And move the format information into the requirements section
(and fix spelling: `node_announement` -> `node_announcement`

Diff for extract-formats.py before and after:

```diff
--- /tmp/before	2022-05-17 10:47:01.583086352 +0930
+++ /tmp/after	2022-05-17 10:51:59.166850111 +0930
@@ -6,6 +6,8 @@
 msgdata,init,tlvs,init_tlvs,
 tlvtype,init_tlvs,networks,1
 tlvdata,init_tlvs,networks,chains,chain_hash,...
+tlvtype,init_tlvs,remote_addr,3
+tlvdata,init_tlvs,remote_addr,data,byte,...
 msgtype,error,17
 msgdata,error,channel_id,channel_id,
 msgdata,error,len,u16,
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>