### PR TITLE
Relay amounts lower than min_htlc if fee is high enough

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -915,15 +915,6 @@ the onion.
 The onion specified a `short_channel_id` which doesn't match any
 leading from the processing node.
 
-1. type: UPDATE|11 (`amount_below_minimum`)
-2. data:
-   * [`u64`:`htlc_msat`]
-   * [`u16`:`len`]
-   * [`len*byte`:`channel_update`]
-
-The HTLC amount was below the `htlc_minimum_msat` of the channel from
-the processing node.
-
 1. type: UPDATE|12 (`fee_insufficient`)
 2. data:
    * [`u64`:`htlc_msat`]
@@ -1068,10 +1059,6 @@ A _forwarding node_ MAY, but a _final node_ MUST NOT:
     - return a `required_channel_feature_missing` error.
   - if the receiving peer specified by the onion is NOT known:
     - return an `unknown_next_peer` error.
-  - if the HTLC amount is less than the currently specified minimum amount:
-    - report the amount of the outgoing HTLC and the current channel setting for
-    the outgoing channel.
-    - return an `amount_below_minimum` error.
   - if the HTLC does NOT pay a sufficient fee:
     - report the amount of the incoming HTLC and the current channel setting for
     the outgoing channel.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -962,10 +962,16 @@ allows for more refined synchronization.
 
 The origin node:
   - SHOULD accept HTLCs that pay a fee equal to or greater than:
-    - fee_base_msat + ( amount_to_forward * fee_proportional_millionths / 1000000 )
+    - fee_base_msat + ( max(amount_to_forward, htlc_minimum_msat) * fee_proportional_millionths / 1000000 )
   - SHOULD accept HTLCs that pay an older fee, for some reasonable time after
   sending `channel_update`.
     - Note: this allows for any propagation delay.
+
+### Rationale
+
+The purpose of `htlc_minimum_msat` is to reject uneconomical HTLCs, however
+lower amounts should still be accepted as long as the fee is high enough to
+relay `htlc_minimum_msat`.
 
 ## Pruning the Network View
 


### PR DESCRIPTION
There is no reason to reject HTLCs with amounts below `htlc_minimum_msat` if the fees are high enough to pay for `htlc_minimum_msat`.