### PR TITLE
option_closing_rejected: turn-based fee_range coop close

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -45,6 +45,7 @@ The Context column decodes as follows:
 | 46/47 | `option_scid_alias`              | Supply channel aliases for routing                        | IN       |                   | [BOLT #2][bolt02-channel-ready]   |
 | 48/49 | `option_payment_metadata` | Payment metadata in tlv record | 9 | | [BOLT #11](11-payment-encoding.md#tagged-fields)
 | 50/51 | `option_zeroconf`                | Understands zeroconf channel types                        | IN       | `option_scid_alias` | [BOLT #2][bolt02-channel-ready]   |
+| 60/61 | `option_closing_rejected` | Turn-based fee_range coop closing | IN | | [BOLT #2][bolt02-closing-signed]
 
 ## Definitions
 
@@ -92,6 +93,7 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 [bolt02-open]: 02-peer-protocol.md#the-open_channel-message
 [bolt03-htlc-tx]: 03-transactions.md#htlc-timeout-and-htlc-success-transactions
 [bolt02-shutdown]: 02-peer-protocol.md#closing-initiation-shutdown
+[bolt02-closing-signed]: 02-peer-protocol.md#closing-negotiation-closingsigned
 [bolt02-channel-ready]: 02-peer-protocol.md#the-channel_ready-message
 [bolt04]: 04-onion-routing.md
 [bolt07-sync]: 07-routing-gossip.md#initial-sync


### PR DESCRIPTION
Adds a feature bit. It's optional, but does simplify some of the spec logic and I think it's nice to have. The naming can change. It works with simple-taproot-channels to allow sending musig2 nonces in a turn-based way.

Fixes https://github.com/lightning/bolts/issues/1013