### PR TITLE
Negative fees

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -423,8 +423,8 @@ of *relaying* payments, not *sending* payments. When making a payment
     * [`byte`:`channel_flags`]
     * [`u16`:`cltv_expiry_delta`]
     * [`u64`:`htlc_minimum_msat`]
-    * [`u32`:`fee_base_msat`]
-    * [`u32`:`fee_proportional_millionths`]
+    * [`i32`:`fee_base_msat`]
+    * [`i32`:`fee_proportional_millionths`]
     * [`u64`:`htlc_maximum_msat`]
 
 The `channel_flags` bitfield is used to indicate the direction of the channel: it


### PR DESCRIPTION
This change allows nodes to advertise a negative forwarding fee.

At the moment, there are no known pathfinding implementations that accept negative fees. This spec change is a first preparatory step towards that goal. A possible roadmap looks like this:

1. Switch fee data type to signed integer (this PR). When a node advertises a negative fee, existing implementations will interpret this as a very high positive fee. The channel will never be used because it is so expensive. Because of that, nodes won't advertise negative fees yet.

2. Implementations start parsing the fee as a signed integer, but convert negative numbers to zero to not break their pathfinding implementations. Nodes can advertise negative fees, but this is effectively the same as advertising zero fees. Those channels won't be skipped anymore as in phase 1. 

    During forwarding, a negative fee is accepted. This means that the outgoing htlc amount may be less than the incoming htlc amount.

   Implementations that have a final route building post-processing pass such as `lnd`, custom pathfinders and users that build routes manually are able get some benefit from the negative fee already.

3. Implementations can choose to implement pathfinding algorithms that support negative edge weights such as bellman-ford to take maximum advantage of the negative fees.
 
The reason for making this spec change now is that it takes time to reach phase 2. Up to that point, changes are minor, but do unblock phase 3.