### PR TITLE
Allow nodes to overshoot the MPP `total_msat` when paying

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -292,7 +292,7 @@ The writer:
     - otherwise:
       - MUST set `total_msat` to the amount it wishes to pay.
     - MUST ensure that the total `amount_msat` of the HTLC set which arrives at the payee
-      is equal to `total_msat`.
+      is equal to or greater than `total_msat`.
     - MUST NOT send another HTLC if the total `amount_msat` of the HTLC set is already greater or equal to `total_msat`.
     - MUST include `payment_secret`.
   - otherwise:
@@ -307,7 +307,8 @@ The final node:
     - MUST add it to the HTLC set corresponding to that `payment_hash`.
     - SHOULD fail the entire HTLC set if `total_msat` is not the same for
       all HTLCs in the set.
-    - if the total `amount_msat` of this HTLC set equals `total_msat`:
+    - if the total `amount_msat` of this HTLC set is equal to or greater than
+      `total_msat`:
       - SHOULD fulfill all HTLCs in the HTLC set
     - otherwise, if the total `amount_msat` of this HTLC set is less than
       `total_msat`:
@@ -332,6 +333,13 @@ sent explicitly.  The requirements allow exceeding this slightly, as
 it simplifies adding noise to the amount when splitting, as well as
 scenarios in which the senders are genuinely independent (friends
 splitting a bill, for example).
+
+Because a node may need to pay more than its desired amount (due to the
+`htlc_minimum_msat` value of channels in the desired path), nodes are allowed
+to pay more than the `total_msat` they specified. Otherwise, nodes would be
+constrained in which paths they can take when retrying payments along specific
+paths. However, no individual HTLC may be for less than the difference between
+the total paid and `total_msat`.
 
 The restriction on sending an HTLC once the set is over the agreed total prevents the preimage being released before all
 the partial payments have arrived: that would allow any intermediate


### PR DESCRIPTION
When a node retires a failed path as part of a larger MPP payment, the node may wish to use a path which is constrained by an `htlc_minimum_msat` value. In this case, the node is forced to overpay, likely overshooting the `total_msat` it set in the earlier onions for the same MPP payment.

There are two possible solutions to this - either allow the `total_msat` value to change in later HTLCs or allow the node to (slightly) overshoot the `total_msat` value.

Allowing `total_msat` to change across HTLCs is nontrivial to implement - HTLCs may arrive out-of-order, causing the receiving node to have to track all seen `total_msat` values and accept a set of HTLCs which meet any of the seen `total_msat` values.

Instead, this commit changes the MPP logic to simply allow a sender to overshoot the stated `total_msat`.

Sadly the backwards-compatibility story for this is not great. There doesn't seem to be a good way to resolve this issue in a backwards-compatible way. Instead we just bite the bullet and make the incompatible change, hoping the overshooting is rare enough that it's not a major issue.