### PR TITLE
Rework `channel_reestablish` requirements

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1403,6 +1403,12 @@ A node:
       - Note: a node MAY have already used the `payment_preimage` value from
         the `update_fulfill_htlc`, so the effects of `update_fulfill_htlc` are not
         completely reversed.
+    - MUST NOT assume that previously-transmitted messages were lost.
+    - if it has sent a previous `commitment_signed` message:
+      - MUST handle the case where the corresponding commitment transaction is
+        broadcast at any time by the other side.
+        - Note: this is particularly important if the node does not simply
+          retransmit the exact `update_` messages as previously sent.
   - upon reconnection:
     - if a channel is in an error state:
       - SHOULD retransmit the error packet and ignore any other packets for
@@ -1438,6 +1444,8 @@ A node:
       a different `short_channel_id` `alias` field.
   - upon reconnection:
     - MUST ignore any redundant `channel_ready` it receives.
+    - if it has sent a previous `shutdown`:
+      - MUST retransmit `shutdown`.
   - if `next_commitment_number` is equal to the commitment number of
     the last `commitment_signed` message the receiving node has sent:
     - MUST reuse the same commitment number for its next `commitment_signed`.
@@ -1486,17 +1494,6 @@ A node:
     - otherwise (`your_last_per_commitment_secret` or `my_current_per_commitment_point`
       do not match the expected values):
       - SHOULD send an `error` and fail the channel.
-
-A node:
-  - MUST NOT assume that previously-transmitted messages were lost,
-    - if it has sent a previous `commitment_signed` message:
-      - MUST handle the case where the corresponding commitment transaction is
-        broadcast at any time by the other side,
-        - Note: this is particularly important if the node does not simply
-          retransmit the exact `update_` messages as previously sent.
-  - upon reconnection:
-    - if it has sent a previous `shutdown`:
-      - MUST retransmit `shutdown`.
 
 ### Rationale
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1398,15 +1398,15 @@ A node:
   - MUST handle continuation of a previous channel on a new encrypted transport.
   - upon disconnection:
     - MUST reverse any uncommitted updates sent by the other side (i.e. all
-    messages beginning with `update_` for which no `commitment_signed` has
-    been received).
+      messages beginning with `update_` for which no `commitment_signed` has
+      been received).
       - Note: a node MAY have already used the `payment_preimage` value from
-    the `update_fulfill_htlc`, so the effects of `update_fulfill_htlc` are not
-    completely reversed.
+        the `update_fulfill_htlc`, so the effects of `update_fulfill_htlc` are not
+        completely reversed.
   - upon reconnection:
     - if a channel is in an error state:
       - SHOULD retransmit the error packet and ignore any other packets for
-      that channel.
+        that channel.
     - otherwise:
       - MUST transmit `channel_reestablish` for each channel.
       - MUST wait to receive the other node's `channel_reestablish`
@@ -1414,9 +1414,9 @@ A node:
 
 The sending node:
   - MUST set `next_commitment_number` to the commitment number of the
-  next `commitment_signed` it expects to receive.
+    next `commitment_signed` it expects to receive.
   - MUST set `next_revocation_number` to the commitment number of the
-  next `revoke_and_ack` message it expects to receive.
+    next `revoke_and_ack` message it expects to receive.
   - if `option_static_remotekey` applies to the commitment
     transaction:
     - MUST set `my_current_per_commitment_point` to a valid point.
@@ -1431,7 +1431,7 @@ The sending node:
 
 A node:
   - if `next_commitment_number` is 1 in both the `channel_reestablish` it
-  sent and received:
+    sent and received:
     - MUST retransmit `channel_ready`.
   - otherwise:
     - MUST NOT retransmit `channel_ready`, but MAY send `channel_ready` with
@@ -1439,37 +1439,37 @@ A node:
   - upon reconnection:
     - MUST ignore any redundant `channel_ready` it receives.
   - if `next_commitment_number` is equal to the commitment number of
-  the last `commitment_signed` message the receiving node has sent:
+    the last `commitment_signed` message the receiving node has sent:
     - MUST reuse the same commitment number for its next `commitment_signed`.
   - otherwise:
-    - if `next_commitment_number` is not 1 greater than the
-  commitment number of the last `commitment_signed` message the receiving
-  node has sent:
+    - if `next_commitment_number` is not 1 greater than the commitment number
+      of the last `commitment_signed` message the receiving
+      node has sent:
       - SHOULD send an `error` and fail the channel.
     - if it has not sent `commitment_signed`, AND `next_commitment_number`
-    is not equal to 1:
+      is not equal to 1:
       - SHOULD send an `error` and fail the channel.
   - if `next_revocation_number` is equal to the commitment number of
-  the last `revoke_and_ack` the receiving node sent, AND the receiving node
-  hasn't already received a `closing_signed`:
+    the last `revoke_and_ack` the receiving node sent, AND the receiving node
+    hasn't already received a `closing_signed`:
     - MUST re-send the `revoke_and_ack`.
     - if it has previously sent a `commitment_signed` that needs to be
-    retransmitted:
+      retransmitted:
       - MUST retransmit `revoke_and_ack` and `commitment_signed` in the same
-      relative order as initially transmitted.
+        relative order as initially transmitted.
   - otherwise:
     - if `next_revocation_number` is not equal to 1 greater than the
-    commitment number of the last `revoke_and_ack` the receiving node has sent:
+      commitment number of the last `revoke_and_ack` the receiving node has sent:
       - SHOULD send an `error` and fail the channel.
     - if it has not sent `revoke_and_ack`, AND `next_revocation_number`
-    is not equal to 0:
+      is not equal to 0:
       - SHOULD send an `error` and fail the channel.
 
  A receiving node:
   - if `option_static_remotekey` applies to the commitment transaction:
     - if `next_revocation_number` is greater than expected above, AND
-    `your_last_per_commitment_secret` is correct for that
-    `next_revocation_number` minus 1:
+      `your_last_per_commitment_secret` is correct for that
+      `next_revocation_number` minus 1:
       - MUST NOT broadcast its commitment transaction.
       - SHOULD send an `error` to request the peer to fail the channel.
     - otherwise:
@@ -1477,23 +1477,23 @@ A node:
         - SHOULD send an `error` and fail the channel.
   - otherwise, if it supports `option_data_loss_protect`:
     - if `next_revocation_number` is greater than expected above, AND
-    `your_last_per_commitment_secret` is correct for that
-    `next_revocation_number` minus 1:
+      `your_last_per_commitment_secret` is correct for that
+      `next_revocation_number` minus 1:
       - MUST NOT broadcast its commitment transaction.
       - SHOULD send an `error` to request the peer to fail the channel.
       - SHOULD store `my_current_per_commitment_point` to retrieve funds
         should the sending node broadcast its commitment transaction on-chain.
     - otherwise (`your_last_per_commitment_secret` or `my_current_per_commitment_point`
-    do not match the expected values):
+      do not match the expected values):
       - SHOULD send an `error` and fail the channel.
 
 A node:
   - MUST NOT assume that previously-transmitted messages were lost,
     - if it has sent a previous `commitment_signed` message:
       - MUST handle the case where the corresponding commitment transaction is
-      broadcast at any time by the other side,
+        broadcast at any time by the other side,
         - Note: this is particularly important if the node does not simply
-        retransmit the exact `update_` messages as previously sent.
+          retransmit the exact `update_` messages as previously sent.
   - upon reconnection:
     - if it has sent a previous `shutdown`:
       - MUST retransmit `shutdown`.


### PR DESCRIPTION
This is an alternative to #1049 which changes the requirements more in-depth.

I started from [our code](https://github.com/ACINQ/eclair/blob/351666dbc9211b3b7ac6c1bd7996d3acb34366af/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala#L467) and rewrote the requirements based on that. I'm trying to more clearly express the fact that the only possible errors cases are:

- we've lost data and our peer correctly proved it (by showing our valid future commitment secret): we absolutely must not broadcast our (revoked) commitment and must ask our peer to kindly broadcast theirs
- we may have lost data, but our peer couldn't prove it: we should probably not broadcast our commitment, because it may or may not be revoked, but if our peer doesn't broadcast theirs either, we may be forced to eventually broadcast if we're confident that we haven't lost data (but that should be a manual step from the node operator)
- our peer tried to make us think we lost data but they lied (by showing an invalid commitment secret): they're malicious, we should call their bluff: just send an `error` and wait for them to force-close (unless the node operator steps in to manually force close)
- our peer seems to have lost data: they will realize it when receiving our `channel_reestablish`, we should wait for them to either send an `error` (if they want us to force-close), or reconnect and send a different `channel_reestablish` (if they've fixed their state backup)

This is harder to express in spec than in code, I may have gotten it wrong or missed a case, so please spend some time carefully reviewing this!

This should close #934 once and for all :tada: 