### PR TITLE
extension-bolt: taproot gossip (features 70/71/72/73/74/75)

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -624,13 +624,13 @@ Nodes can signal that they support extended gossip queries with the `gossip_quer
 
 `encoded_query_flags` is an array of bitfields, one bigsize per bitfield, one bitfield for each `short_channel_id`. Bits have the following meaning:
 
-| Bit Position  | Meaning                                  |
-| ------------- | ---------------------------------------- |
-| 0             | Sender wants `channel_announcement`      |
-| 1             | Sender wants `channel_update` for node 1 |
-| 2             | Sender wants `channel_update` for node 2 |
-| 3             | Sender wants `node_announcement` for node 1 |
-| 4             | Sender wants `node_announcement` for node 2 |
+| Bit Position | Meaning                                           |
+|--------------|---------------------------------------------------|
+| 0            | Sender wants `channel_announcement`/`_2`          |
+| 1            | Sender wants `channel_update`/`_2` for node 1     |
+| 2            | Sender wants `channel_update`/`_2` for node 2     |
+| 3            | Sender wants `node_announcement`/`_2` for node 1  |
+| 4            | Sender wants `node_announcement`/`_2` for node 2  |
 
 Query flags must be minimally encoded, which means that one flag will be encoded with a single byte.
 
@@ -640,11 +640,11 @@ Query flags must be minimally encoded, which means that one flag will be encoded
     * [`byte`:`full_information`]
 
 This is a general mechanism which lets a node query for the
-`channel_announcement` and `channel_update` messages for specific channels
-(identified via `short_channel_id`s). This is usually used either because
-a node sees a `channel_update` for which it has no `channel_announcement` or
-because it has obtained previously unknown `short_channel_id`s
-from `reply_channel_range`.
+`channel_announcement`/`_2` and `channel_update`/`_2` messages for specific 
+channels (identified via `short_channel_id`s). This is usually used either 
+because a node sees a `channel_update`/`_2` for which it has no 
+`channel_announcement`/`_2` or because it has obtained previously unknown 
+`short_channel_id`s from `reply_channel_range`.
 
 #### Requirements
 
@@ -655,7 +655,7 @@ The sender:
   that the `short_channel_id`s refer to.
   - MUST set the first byte of `encoded_short_ids` to the encoding type.
   - MUST encode a whole number of `short_channel_id`s to `encoded_short_ids`
-  - MAY send this if it receives a `channel_update` for a
+  - MAY send this if it receives a `channel_update`/`_2` for a
    `short_channel_id` for which it has no `channel_announcement`.
   - SHOULD NOT send this if the channel referred to is not an unspent output.
   - MAY include an optional `query_flags`. If so:
@@ -682,24 +682,25 @@ The receiver:
       - MAY close the connection.
   - MUST respond to each known `short_channel_id`:
     - if the incoming message does not include `encoded_query_flags`:
-      - with a `channel_announcement` and the latest `channel_update` for each end
-      - MUST follow with any `node_announcement`s for each `channel_announcement`
+      - with a `channel_announcement`/`_2` and the latest `channel_update`/_2` 
+        for each end
+      - MUST follow with any `node_announcement`/`_2`s for each `channel_announcement`/`_2`
     - otherwise:
       - We define `query_flag` for the Nth `short_channel_id` in
         `encoded_short_ids` to be the Nth bigsize of the decoded
         `encoded_query_flags`.
       - if bit 0 of `query_flag` is set:
-        - MUST reply with a `channel_announcement`
-      - if bit 1 of `query_flag` is set and it has received a `channel_update` from `node_id_1`:
-        - MUST reply with the latest `channel_update` for `node_id_1`
-      - if bit 2 of `query_flag` is set and it has received a `channel_update` from `node_id_2`:
-        - MUST reply with the latest `channel_update` for `node_id_2`
-      - if bit 3 of `query_flag` is set and it has received a `node_announcement` from `node_id_1`:
-        - MUST reply with the latest `node_announcement` for `node_id_1`
-      - if bit 4 of `query_flag` is set and it has received a `node_announcement` from `node_id_2`:
-        - MUST reply with the latest `node_announcement` for `node_id_2`
+        - MUST reply with a `channel_announcement`/`_2`
+      - if bit 1 of `query_flag` is set and it has received a `channel_update`/`_2` from `node_id_1`:
+        - MUST reply with the latest `channel_update`/`_2` for `node_id_1`
+      - if bit 2 of `query_flag` is set and it has received a `channel_update`/`_2` from `node_id_2`:
+        - MUST reply with the latest `channel_update`/`_2` for `node_id_2`
+      - if bit 3 of `query_flag` is set and it has received a `node_announcement`/`_2` from `node_id_1`:
+        - MUST reply with the latest `node_announcement`/`_2` for `node_id_1`
+      - if bit 4 of `query_flag` is set and it has received a `node_announcement`/`_2` from `node_id_2`:
+        - MUST reply with the latest `node_announcement`/`_2` for `node_id_2`
     - SHOULD NOT wait for the next outgoing gossip flush to send these.
-  - SHOULD avoid sending duplicate `node_announcements` in response to a single `query_short_channel_ids`.
+  - SHOULD avoid sending duplicate `node_announcements`/`_2` in response to a single `query_short_channel_ids`.
   - MUST follow these responses with `reply_short_channel_ids_end`.
   - if does not maintain up-to-date channel information for `chain_hash`:
     - MUST set `full_information` to 0.
@@ -734,12 +735,12 @@ timeouts.  It also causes a natural ratelimiting of queries.
 
 `query_option_flags` is a bitfield represented as a minimally-encoded bigsize. Bits have the following meaning:
 
-| Bit Position  | Meaning                 |
-| ------------- | ----------------------- |
-| 0             | Sender wants timestamps |
-| 1             | Sender wants checksums  |
+| Bit Position | Meaning                               |
+|--------------|---------------------------------------|
+| 0            | Sender wants timestamps/block heights |
+| 1            | Sender wants checksums                |
 
-Though it is possible, it would not be very useful to ask for checksums without asking for timestamps too: the receiving node may have an older `channel_update` with a different checksum, asking for it would be useless. And if a `channel_update` checksum is actually 0 (which is quite unlikely) it will not be queried.
+Though it is possible, it would not be very useful to ask for checksums without asking for timestamps/block heights too: the receiving node may have an older `channel_update` with a different checksum, asking for it would be useless. And if a `channel_update` checksum is actually 0 (which is quite unlikely) it will not be queried.
 
 1. type: 264 (`reply_channel_range`)
 2. data:
@@ -753,15 +754,21 @@ Though it is possible, it would not be very useful to ask for checksums without 
 
 1. `tlv_stream`: `reply_channel_range_tlvs`
 2. types:
-    1. type: 1 (`timestamps_tlv`)
+    1. type: 1 (`timestamps_blockheights_tlv`)
     2. data:
         * [`byte`:`encoding_type`]
-        * [`...*byte`:`encoded_timestamps`]
+        * [`...*byte`:`encoded_timestamps_blockheights`]
     1. type: 3 (`checksums_tlv`)
     2. data:
         * [`...*channel_update_checksums`:`checksums`]
 
-For a single `channel_update`, timestamps are encoded as:
+For the `timestamps_blockheights_tlv` field, the contents depends on whether the
+associated channel update message is for a channel announced using 
+`channel_announcement` or `channel_announcement_2`. 
+
+If the channel was announced using `channel_announcement`, then the associated 
+update will be a `channel_update`, meaning that the contents will represent 
+timestamps and will be encoded as:
 
 1. subtype: `channel_update_timestamps`
 2. data:
@@ -772,7 +779,20 @@ Where:
 * `timestamp_node_id_1` is the timestamp of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
 * `timestamp_node_id_2` is the timestamp of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
 
-For a single `channel_update`, checksums are encoded as:
+If the channel was announced usig `channel_announcement_2`, then the associated 
+update is a `channel_update_2` and the contents will represent block heights and 
+will be encoded as:
+
+1. subtype: `channel_update_blockheights`
+2. data:
+    * [`u32`:`block_height_node_id_1`]
+    * [`u32`:`block_height_node_id_2`]
+
+Where:
+* `block_height_node_id_1` is the block height of the `channel_update_2` for `node_id_1`, or 0 if there was no `channel_update_2` from that node.
+* `block_height_node_id_2` is the block height of the `channel_update_2` for `node_id_2`, or 0 if there was no `channel_update_2` from that node.
+
+For a single `channel_update`/`_2`, checksums are encoded as:
 
 1. subtype: `channel_update_checksums`
 2. data:
@@ -780,10 +800,10 @@ For a single `channel_update`, checksums are encoded as:
     * [`u32`:`checksum_node_id_2`]
 
 Where:
-* `checksum_node_id_1` is the checksum of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
-* `checksum_node_id_2` is the checksum of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
+* `checksum_node_id_1` is the checksum of the `channel_update`/`_2` for `node_id_1`, or 0 if there was no `channel_update`/`_2` from that node.
+* `checksum_node_id_2` is the checksum of the `channel_update`/`_2` for `node_id_2`, or 0 if there was no `channel_update`/`_2` from that node.
 
-The checksum of a `channel_update` is the CRC32C checksum as specified in [RFC3720](https://tools.ietf.org/html/rfc3720#appendix-B.4) of this `channel_update` without its `signature` and `timestamp` fields.
+The checksum of a `channel_update`/`_2` is the CRC32C checksum as specified in [RFC3720](https://tools.ietf.org/html/rfc3720#appendix-B.4) of this `channel_update`/`_2` without its `signature` and `timestamp`/`block_height` fields.
 
 This allows querying for channels within specific blocks.
 
@@ -807,6 +827,10 @@ The receiver of `query_channel_range`:
     - MUST limit `number_of_blocks` to the maximum number of blocks whose
       results could fit in `encoded_short_ids`
     - MAY split block contents across multiple `reply_channel_range`.
+    - If the sender of `query_channel_range` has not advertised the 
+      `option_taproot_gossip` feature bit then the response MUST only include 
+      short channel IDs for channels announced with the `channel_announcement` 
+      message.
     - the first `reply_channel_range` message:
       - MUST set `first_blocknum` less than or equal to the `first_blocknum` in `query_channel_range`
       - MUST set `first_blocknum` plus `number_of_blocks` greater than `first_blocknum` in `query_channel_range`.
@@ -818,7 +842,7 @@ The receiver of `query_channel_range`:
     - MUST set `sync_complete` to `true`.
 
 If the incoming message includes `query_option`, the receiver MAY append additional information to its reply:
-- if bit 0 in `query_option_flags` is set, the receiver MAY append a `timestamps_tlv` that contains `channel_update` timestamps for all `short_channel_id`s in `encoded_short_ids`
+- if bit 0 in `query_option_flags` is set, the receiver MAY append a `timestamps_blockheights_tlv` that contains `channel_update`/`_2` timestamps for all `short_channel_id`s in `encoded_short_ids`
 - if bit 1 in `query_option_flags` is set, the receiver MAY append a `checksums_tlv` that contains `channel_update` checksums for all `short_channel_id`s in `encoded_short_ids`
 
 #### Rationale
@@ -842,6 +866,16 @@ The addition of timestamp and checksum fields allow a peer to omit querying for 
     * [`chain_hash`:`chain_hash`]
     * [`u32`:`first_timestamp`]
     * [`u32`:`timestamp_range`]
+    * [`gossip_timestamps_filter_tlvs`:`tlvs`]
+
+1. `tlv_stream`: `gossip_timestamps_filter_tlvs`
+2. types:
+    1. type: 2 (`first_block`)
+    2. data:
+        * [`u32`:`block_height`]
+   1. type: 4 (`block_height_range`)
+   2. data:
+       * [`u32`:`num_blocks`]
 
 This message allows a node to constrain future gossip messages to
 a specific range.  A node which wants any gossip messages has
@@ -861,20 +895,26 @@ The sender:
 The receiver:
   - SHOULD send all gossip messages whose `timestamp` is greater or
     equal to `first_timestamp`, and less than `first_timestamp` plus
-    `timestamp_range`.
+    `timestamp_range`. This applies to the messages: `channel_announcement`, 
+    `channel_update` and `node_announcement`.
     - MAY wait for the next outgoing gossip flush to send these.
-  - SHOULD send gossip messages as it generates them regardless of `timestamp`.
+  - SHOULD send all gossip messages whose `block_height` is greater than or 
+    equal to `first_block`, and less than `first_block` plus `num_blocks`. 
+  - SHOULD send gossip messages as it generates them regardless of `timestamp`/`block_height`.
   - Otherwise (relayed gossip):
     - SHOULD restrict future gossip messages to those whose `timestamp`
       is greater or equal to `first_timestamp`, and less than
-      `first_timestamp` plus `timestamp_range`.
-  - If a `channel_announcement` has no corresponding `channel_update`s:
-    - MUST NOT send the `channel_announcement`.
+      `first_timestamp` plus `timestamp_range` or whose `block_height` is 
+      greater than or equal to `first_block`, and less than `first_block` plus 
+      `num_blocks`.
+  - If a `channel_announcement`/`_2` has no corresponding `channel_update`/`_2`s:
+    - MUST NOT send the `channel_announcement`/`_2`.
   - Otherwise:
     - MUST consider the `timestamp` of the `channel_announcement` to be the `timestamp` of a corresponding `channel_update`.
-    - MUST consider whether to send the `channel_announcement` after receiving the first corresponding `channel_update`.
-  - If a `channel_announcement` is sent:
-    - MUST send the `channel_announcement` prior to any corresponding `channel_update`s and `node_announcement`s.
+    - MUST consider the `block_height` of the `channel_announcement_2` to be the height of the block it was mined in.
+    - MUST consider whether to send the `channel_announcement`/`_2` after receiving the first corresponding `channel_update`/`_2`.
+  - If a `channel_announcement`/`_2` is sent:
+    - MUST send the `channel_announcement`/`_2` prior to any corresponding `channel_update`/`_2`s and `node_announcement`/`_2`s.
 
 #### Rationale
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -900,12 +900,10 @@ The addition of timestamp and checksum fields allow a peer to omit querying for 
 
 1. `tlv_stream`: `gossip_timestamps_filter_tlvs`
 2. types:
-    1. type: 2 (`first_block`)
+    1. type: 2 (`block_height_range`)
     2. data:
-        * [`u32`:`block_height`]
-   1. type: 4 (`block_height_range`)
-   2. data:
-       * [`u32`:`num_blocks`]
+        * [`u32`:`first_block_height`]
+        * [`tu32`:`num_blocks`]
 
 This message allows a node to constrain future gossip messages to
 a specific range.  A node which wants any gossip messages has
@@ -929,14 +927,14 @@ The receiver:
     `channel_update` and `node_announcement`.
     - MAY wait for the next outgoing gossip flush to send these.
   - SHOULD send all gossip messages whose `block_height` is greater than or 
-    equal to `first_block`, and less than `first_block` plus `num_blocks`. 
+    equal to `first_block_height`, and less than `first_block_height` plus `num_blocks`. 
   - SHOULD send gossip messages as it generates them regardless of `timestamp`/`block_height`.
   - Otherwise (relayed gossip):
     - SHOULD restrict future gossip messages to those whose `timestamp`
       is greater or equal to `first_timestamp`, and less than
       `first_timestamp` plus `timestamp_range` or whose `block_height` is 
-      greater than or equal to `first_block`, and less than `first_block` plus 
-      `num_blocks`.
+      greater than or equal to `first_block_height`, and less than 
+      `first_block_height` plus `num_blocks`.
   - If a `channel_announcement`/`_2` has no corresponding `channel_update`/`_2`s:
     - MUST NOT send the `channel_announcement`/`_2`.
   - Otherwise:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -654,13 +654,13 @@ Nodes can signal that they support extended gossip queries with the `gossip_quer
 
 `encoded_query_flags` is an array of bitfields, one bigsize per bitfield, one bitfield for each `short_channel_id`. Bits have the following meaning:
 
-| Bit Position  | Meaning                                  |
-| ------------- | ---------------------------------------- |
-| 0             | Sender wants `channel_announcement`      |
-| 1             | Sender wants `channel_update` for node 1 |
-| 2             | Sender wants `channel_update` for node 2 |
-| 3             | Sender wants `node_announcement` for node 1 |
-| 4             | Sender wants `node_announcement` for node 2 |
+| Bit Position | Meaning                                           |
+|--------------|---------------------------------------------------|
+| 0            | Sender wants `channel_announcement`/`_2`          |
+| 1            | Sender wants `channel_update`/`_2` for node 1     |
+| 2            | Sender wants `channel_update`/`_2` for node 2     |
+| 3            | Sender wants `node_announcement`/`_2` for node 1  |
+| 4            | Sender wants `node_announcement`/`_2` for node 2  |
 
 Query flags must be minimally encoded, which means that one flag will be encoded with a single byte.
 
@@ -670,11 +670,11 @@ Query flags must be minimally encoded, which means that one flag will be encoded
     * [`byte`:`full_information`]
 
 This is a general mechanism which lets a node query for the
-`channel_announcement` and `channel_update` messages for specific channels
-(identified via `short_channel_id`s). This is usually used either because
-a node sees a `channel_update` for which it has no `channel_announcement` or
-because it has obtained previously unknown `short_channel_id`s
-from `reply_channel_range`.
+`channel_announcement`/`_2` and `channel_update`/`_2` messages for specific 
+channels (identified via `short_channel_id`s). This is usually used either 
+because a node sees a `channel_update`/`_2` for which it has no 
+`channel_announcement`/`_2` or because it has obtained previously unknown 
+`short_channel_id`s from `reply_channel_range`.
 
 #### Requirements
 
@@ -685,7 +685,7 @@ The sender:
   that the `short_channel_id`s refer to.
   - MUST set the first byte of `encoded_short_ids` to the encoding type.
   - MUST encode a whole number of `short_channel_id`s to `encoded_short_ids`
-  - MAY send this if it receives a `channel_update` for a
+  - MAY send this if it receives a `channel_update`/`_2` for a
    `short_channel_id` for which it has no `channel_announcement`.
   - SHOULD NOT send this if the channel referred to is not an unspent output.
   - MAY include an optional `query_flags`. If so:
@@ -712,24 +712,25 @@ The receiver:
       - MAY close the connection.
   - MUST respond to each known `short_channel_id`:
     - if the incoming message does not include `encoded_query_flags`:
-      - with a `channel_announcement` and the latest `channel_update` for each end
-      - MUST follow with any `node_announcement`s for each `channel_announcement`
+      - with a `channel_announcement`/`_2` and the latest `channel_update`/_2` 
+        for each end
+      - MUST follow with any `node_announcement`/`_2`s for each `channel_announcement`/`_2`
     - otherwise:
       - We define `query_flag` for the Nth `short_channel_id` in
         `encoded_short_ids` to be the Nth bigsize of the decoded
         `encoded_query_flags`.
       - if bit 0 of `query_flag` is set:
-        - MUST reply with a `channel_announcement`
-      - if bit 1 of `query_flag` is set and it has received a `channel_update` from `node_id_1`:
-        - MUST reply with the latest `channel_update` for `node_id_1`
-      - if bit 2 of `query_flag` is set and it has received a `channel_update` from `node_id_2`:
-        - MUST reply with the latest `channel_update` for `node_id_2`
-      - if bit 3 of `query_flag` is set and it has received a `node_announcement` from `node_id_1`:
-        - MUST reply with the latest `node_announcement` for `node_id_1`
-      - if bit 4 of `query_flag` is set and it has received a `node_announcement` from `node_id_2`:
-        - MUST reply with the latest `node_announcement` for `node_id_2`
+        - MUST reply with a `channel_announcement`/`_2`
+      - if bit 1 of `query_flag` is set and it has received a `channel_update`/`_2` from `node_id_1`:
+        - MUST reply with the latest `channel_update`/`_2` for `node_id_1`
+      - if bit 2 of `query_flag` is set and it has received a `channel_update`/`_2` from `node_id_2`:
+        - MUST reply with the latest `channel_update`/`_2` for `node_id_2`
+      - if bit 3 of `query_flag` is set and it has received a `node_announcement`/`_2` from `node_id_1`:
+        - MUST reply with the latest `node_announcement`/`_2` for `node_id_1`
+      - if bit 4 of `query_flag` is set and it has received a `node_announcement`/`_2` from `node_id_2`:
+        - MUST reply with the latest `node_announcement`/`_2` for `node_id_2`
     - SHOULD NOT wait for the next outgoing gossip flush to send these.
-  - SHOULD avoid sending duplicate `node_announcements` in response to a single `query_short_channel_ids`.
+  - SHOULD avoid sending duplicate `node_announcements`/`_2` in response to a single `query_short_channel_ids`.
   - MUST follow these responses with `reply_short_channel_ids_end`.
   - if does not maintain up-to-date channel information for `chain_hash`:
     - MUST set `full_information` to 0.
@@ -764,12 +765,12 @@ timeouts.  It also causes a natural ratelimiting of queries.
 
 `query_option_flags` is a bitfield represented as a minimally-encoded bigsize. Bits have the following meaning:
 
-| Bit Position  | Meaning                 |
-| ------------- | ----------------------- |
-| 0             | Sender wants timestamps |
-| 1             | Sender wants checksums  |
+| Bit Position | Meaning                               |
+|--------------|---------------------------------------|
+| 0            | Sender wants timestamps/block heights |
+| 1            | Sender wants checksums                |
 
-Though it is possible, it would not be very useful to ask for checksums without asking for timestamps too: the receiving node may have an older `channel_update` with a different checksum, asking for it would be useless. And if a `channel_update` checksum is actually 0 (which is quite unlikely) it will not be queried.
+Though it is possible, it would not be very useful to ask for checksums without asking for timestamps/block heights too: the receiving node may have an older `channel_update` with a different checksum, asking for it would be useless. And if a `channel_update` checksum is actually 0 (which is quite unlikely) it will not be queried.
 
 1. type: 264 (`reply_channel_range`)
 2. data:
@@ -783,15 +784,21 @@ Though it is possible, it would not be very useful to ask for checksums without 
 
 1. `tlv_stream`: `reply_channel_range_tlvs`
 2. types:
-    1. type: 1 (`timestamps_tlv`)
+    1. type: 1 (`timestamps_blockheights_tlv`)
     2. data:
         * [`byte`:`encoding_type`]
-        * [`...*byte`:`encoded_timestamps`]
+        * [`...*byte`:`encoded_timestamps_blockheights`]
     1. type: 3 (`checksums_tlv`)
     2. data:
         * [`...*channel_update_checksums`:`checksums`]
 
-For a single `channel_update`, timestamps are encoded as:
+For the `timestamps_blockheights_tlv` field, the contents depends on whether the
+associated channel update message is for a channel announced using 
+`channel_announcement` or `channel_announcement_2`. 
+
+If the channel was announced using `channel_announcement`, then the associated 
+update will be a `channel_update`, meaning that the contents will represent 
+timestamps and will be encoded as:
 
 1. subtype: `channel_update_timestamps`
 2. data:
@@ -802,7 +809,20 @@ Where:
 * `timestamp_node_id_1` is the timestamp of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
 * `timestamp_node_id_2` is the timestamp of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
 
-For a single `channel_update`, checksums are encoded as:
+If the channel was announced usig `channel_announcement_2`, then the associated 
+update is a `channel_update_2` and the contents will represent block heights and 
+will be encoded as:
+
+1. subtype: `channel_update_blockheights`
+2. data:
+    * [`u32`:`block_height_node_id_1`]
+    * [`u32`:`block_height_node_id_2`]
+
+Where:
+* `block_height_node_id_1` is the block height of the `channel_update_2` for `node_id_1`, or 0 if there was no `channel_update_2` from that node.
+* `block_height_node_id_2` is the block height of the `channel_update_2` for `node_id_2`, or 0 if there was no `channel_update_2` from that node.
+
+For a single `channel_update`/`_2`, checksums are encoded as:
 
 1. subtype: `channel_update_checksums`
 2. data:
@@ -810,10 +830,10 @@ For a single `channel_update`, checksums are encoded as:
     * [`u32`:`checksum_node_id_2`]
 
 Where:
-* `checksum_node_id_1` is the checksum of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
-* `checksum_node_id_2` is the checksum of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
+* `checksum_node_id_1` is the checksum of the `channel_update`/`_2` for `node_id_1`, or 0 if there was no `channel_update`/`_2` from that node.
+* `checksum_node_id_2` is the checksum of the `channel_update`/`_2` for `node_id_2`, or 0 if there was no `channel_update`/`_2` from that node.
 
-The checksum of a `channel_update` is the CRC32C checksum as specified in [RFC3720](https://tools.ietf.org/html/rfc3720#appendix-B.4) of this `channel_update` without its `signature` and `timestamp` fields.
+The checksum of a `channel_update`/`_2` is the CRC32C checksum as specified in [RFC3720](https://tools.ietf.org/html/rfc3720#appendix-B.4) of this `channel_update`/`_2` without its `signature` and `timestamp`/`block_height` fields.
 
 This allows querying for channels within specific blocks.
 
@@ -837,6 +857,10 @@ The receiver of `query_channel_range`:
     - MUST limit `number_of_blocks` to the maximum number of blocks whose
       results could fit in `encoded_short_ids`
     - MAY split block contents across multiple `reply_channel_range`.
+    - If the sender of `query_channel_range` has not advertised the 
+      `option_taproot_gossip` feature bit then the response MUST only include 
+      short channel IDs for channels announced with the `channel_announcement` 
+      message.
     - the first `reply_channel_range` message:
       - MUST set `first_blocknum` less than or equal to the `first_blocknum` in `query_channel_range`
       - MUST set `first_blocknum` plus `number_of_blocks` greater than `first_blocknum` in `query_channel_range`.
@@ -848,7 +872,7 @@ The receiver of `query_channel_range`:
       - MUST set `sync_complete` to `true`.
 
 If the incoming message includes `query_option`, the receiver MAY append additional information to its reply:
-- if bit 0 in `query_option_flags` is set, the receiver MAY append a `timestamps_tlv` that contains `channel_update` timestamps for all `short_channel_id`s in `encoded_short_ids`
+- if bit 0 in `query_option_flags` is set, the receiver MAY append a `timestamps_blockheights_tlv` that contains `channel_update`/`_2` timestamps for all `short_channel_id`s in `encoded_short_ids`
 - if bit 1 in `query_option_flags` is set, the receiver MAY append a `checksums_tlv` that contains `channel_update` checksums for all `short_channel_id`s in `encoded_short_ids`
 
 #### Rationale
@@ -872,6 +896,16 @@ The addition of timestamp and checksum fields allow a peer to omit querying for 
     * [`chain_hash`:`chain_hash`]
     * [`u32`:`first_timestamp`]
     * [`u32`:`timestamp_range`]
+    * [`gossip_timestamps_filter_tlvs`:`tlvs`]
+
+1. `tlv_stream`: `gossip_timestamps_filter_tlvs`
+2. types:
+    1. type: 2 (`first_block`)
+    2. data:
+        * [`u32`:`block_height`]
+   1. type: 4 (`block_height_range`)
+   2. data:
+       * [`u32`:`num_blocks`]
 
 This message allows a node to constrain future gossip messages to
 a specific range.  A node which wants any gossip messages has
@@ -891,22 +925,26 @@ The sender:
 The receiver:
   - SHOULD send all gossip messages whose `timestamp` is greater or
     equal to `first_timestamp`, and less than `first_timestamp` plus
-    `timestamp_range`.
+    `timestamp_range`. This applies to the messages: `channel_announcement`, 
+    `channel_update` and `node_announcement`.
     - MAY wait for the next outgoing gossip flush to send these.
-  - SHOULD send gossip messages as it generates them regardless of `timestamp`.
+  - SHOULD send all gossip messages whose `block_height` is greater than or 
+    equal to `first_block`, and less than `first_block` plus `num_blocks`. 
+  - SHOULD send gossip messages as it generates them regardless of `timestamp`/`block_height`.
   - Otherwise (relayed gossip):
     - SHOULD restrict future gossip messages to those whose `timestamp`
       is greater or equal to `first_timestamp`, and less than
-      `first_timestamp` plus `timestamp_range`.
-  - If a `channel_announcement` has no corresponding `channel_update`s:
-    - MUST NOT send the `channel_announcement`.
-  - If the funding output of the `channel_announcement` has been spent:
-    - SHOULD NOT send the `channel_announcement`.
+      `first_timestamp` plus `timestamp_range` or whose `block_height` is 
+      greater than or equal to `first_block`, and less than `first_block` plus 
+      `num_blocks`.
+  - If a `channel_announcement`/`_2` has no corresponding `channel_update`/`_2`s:
+    - MUST NOT send the `channel_announcement`/`_2`.
   - Otherwise:
     - MUST consider the `timestamp` of the `channel_announcement` to be the `timestamp` of a corresponding `channel_update`.
-    - MUST consider whether to send the `channel_announcement` after receiving the first corresponding `channel_update`.
-  - If a `channel_announcement` is sent:
-    - MUST send the `channel_announcement` prior to any corresponding `channel_update`s and `node_announcement`s.
+    - MUST consider the `block_height` of the `channel_announcement_2` to be the height of the block it was mined in.
+    - MUST consider whether to send the `channel_announcement`/`_2` after receiving the first corresponding `channel_update`/`_2`.
+  - If a `channel_announcement`/`_2` is sent:
+    - MUST send the `channel_announcement`/`_2` prior to any corresponding `channel_update`/`_2`s and `node_announcement`/`_2`s.
 
 #### Rationale
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -1,0 +1,1083 @@
+# Extension BOLT XX: Taproot Gossip
+
+# Table of Contents
+
+  * [Aim](#aim)
+  * [Overview](#overview)
+  * [Terminology](#terminology)
+  * [Type Definitions](#type-definitions)
+  * [TLV Based Messages](#tlv-based-messages)
+  * [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification)
+  * [Timestamp fields](#timestamp-fields)
+  * [Bootstrapping Taproot Gossip](#bootstrapping-taproot-gossip)
+  * [Specification](#specification)
+    * [Feature Bits](#feature-bits)
+    * [The `announcement_signatures_2` message](#the-announcement_signatures_2-message)
+    * [The `channel_announcement_2` message](#the-channel_announcement_2-message)
+    * [The `node_announcement_2` message](#the-node_announcement_2-message)
+    * [The `channel_update_2` message](#the-channel_update_2-message)
+  * [Appendix A: Algorithms](#appendix-a-algorithms)
+      * [Partial Signature Calculation](#partial-signature-calculation)
+      * [Partial Signature Verification](#partial-signature-verification)
+  * [Appendix B: Test Vectors](#appendix-b-test-vectors)
+  * [Acknowledgements](#acknowledgements)
+
+## Aim 
+
+This document aims to update the gossip protocol defined in [BOLT 7][bolt-7] to
+allow for advertisement and verification of taproot channels. An entirely new
+set of gossip messages are defined that use [BIP-340][bip-340] signatures and
+that use a purely TLV based schema.
+
+## Overview
+
+The initial version of the Lightning Network gossip protocol as defined in
+[BOLT 7][bolt-7] was designed around P2WSH funding transactions. For these
+channels, the `channel_announcement` message is used to advertise the channel to
+the rest of the network. Nodes in the network use the content of this message to
+prove that the channel is sufficiently bound to the Lightning Network context
+and that it is owned by the nodes advertising the channel. This proof and
+verification protocol is, however, not compatible with SegWit V1 (P2TR) outputs
+and so cannot be used to advertise the channels defined in the
+[Simple Taproot Channel][simple-taproot-chans] proposal. This document thus aims
+to define an updated gossip protocol that will allow nodes to both advertise and
+verify taproot channels. This part of the update affects the
+`announcement_signatures` and `channel_announcement` messages.
+
+The opportunity is also taken to rework the `node_announcement` and
+`channel_update` messages to take advantage of [BIP-340][bip-340] signatures and
+TLV fields. Timestamp fields are also updated to be block heights instead of
+Unix timestamps.
+
+## Terminology
+
+- Collectively, the set of new gossip messages will be referred to as 
+  `taproot gossip`.
+- `node_1` and `node_2` refer to the two parties involved in opening a channel.
+- `node_ID_1` and `node_ID_2` respectively refer to the public keys that
+  `node_1` and `node_2` use to identify their nodes in the network.
+- `bitcoin_key_1` and `bitcoin_key_2` respectively refer to the public keys
+  that `node_1` and `node_2` will use for the specific channel being opened.
+  The funding transaction's output will be derived from these two keys.
+
+## Type Definitions
+
+The following convenient types are defined:
+
+* `bip340_sig`: a 64-byte bitcoin Elliptic Curve Schnorr signature as
+  per [BIP-340][bip-340].
+* `partial_signature`: a 32-byte partial MuSig2 signature as defined
+  in [BIP-MuSig2][bip-musig2].
+* `public_nonce`: a 66-byte public nonce as defined in [BIP-MuSig2][bip-musig2].
+* `utf8`: a byte as part of a UTF-8 string. A writer MUST ensure an array of
+  these is a valid UTF-8 string, a reader MAY reject any messages containing an
+  array of these which is not a valid UTF-8 string.
+
+## TLV Based Messages
+
+The initial set of Lightning Network messages consisted of fields that had to 
+be present. Later on, TLV encoding was introduced which provided a backward 
+compatible way to extend messages. To ensure that the new messages defined in 
+this document remain as future-proof as possible, the messages will be pure TLV
+streams. By making all fields in the messages TLV records, fields that we
+consider mandatory today can easily be dropped in future (when coupled with a 
+new feature bit) without needing to completely redefine the gossip message in 
+order to make the field optional.
+
+## Taproot Channel Proof and Verification
+
+Taproot channel funding transaction outputs will be SegWit V1 (P2TR) outputs of
+the following form:
+
+```
+OP_1 <taproot_output_key> 
+```
+
+where 
+```
+taproot_internal_key = MuSig2.KeyAgg(MuSig2.KeySort(bitcoin_key_1, bitcoin_key_2))
+
+taproot_output_key = taproot_internal_key + tagged_hash("TapTweak", taproot_internal_key) * G
+```
+
+`taproot_interal_key` is the aggregate key of `bitcoin_key_1` and
+`bitcoin_key_2` after first sorting the keys using the
+[MuSig2 KeySort][musig-keysort] algorithm and then running the
+[MuSig2 KeyAgg][musig-keyagg] algorithm.
+
+Then, to commit to spending the taproot output via the keyspend path, a
+[BIP86][bip86-tweak] tweak is added to the internal key to calculate the
+`taproot_output_key`.
+
+As with legacy channels, nodes will want to perform some checks before adding 
+an announced taproot channel to their routing graph:
+
+1. The funding output of the channel being advertised exists on-chain, is an
+   unspent UTXO and has a sufficient number of confirmations. To allow this 
+   check, the SCID of the channel will continue to be included in the channel
+   announcement.
+2. The funding transaction is sufficiently bound to the Lightning context. 
+   Nodes will do this by checking that they are able to derive the output key 
+   found on-chain by using the advertised `bitcoin_key_1` and `bitcoin_key_2` 
+   along with a [BIP86 tweak][bip86-tweak]. This provides a slightly weaker
+   binding to the LN context than legacy channels do but at least somewhat 
+   limits how the output can be spent due to the script-path being disabled.
+   The context binding with legacy channels is greater because an attacker 
+   trying to create gossip spam would need to create 2-of-2 multisig P2WSH 
+   outputs on-chain that would require them to then pay for the bytes of two
+   signatures at the time of spending the output. This extra cost provided some
+   extra deterrence for attackers. This deterrence is not present with P2TR 
+   transactions.
+3. The owners of `bitcoin_key_1` and `bitcoin_key_2` agree to be associated with  
+   a channel owned by `node_1` and `node_2`.
+4. The owners of `node_ID_1` and `node_ID_2` agree to being associated with the 
+   output paying to `bitcoin_key_1` and `bitcoin_key_2`. 
+
+For legacy channels, these last two proofs are made possible by including four
+separate signatures in the `channel_announcement`. However, [BIP-340][bip-340]
+signatures and the MuSig2 protocol allow us to now aggregate these four
+signatures into a single one. Verifiers will then be able to aggregate the four
+keys (`bitcoin_key_1`, `bitcoin_key_2`, `node_ID_1` and `node_ID_2`) using
+MuSig2 key aggregation and then they can do a single signature verification
+check instead of four individual checks.
+
+## Timestamp fields
+
+In this document, the `timestamp` fields in messages are block heights instead
+of the UNIX timestamps used in the legacy gossip messages. 
+
+### Rate Limiting
+
+A block height based timestamp results in more natural rate limiting for gossip
+messages: nodes are allowed to send at most one announcement and update per
+block. To allow for bursts, nodes are encouraged not to use the latest block
+height for their latest announcements/updates but rather to backdate and use
+older block heights that they have not used in an announcement/update. There of
+course needs to be a limit on the start block height that the node can use:
+for `channel_update_2` messages, the first timestamp must be the block height in
+which the channel funding transaction was mined and all updates after the
+initial one must have increasing timestamps. Nodes are then responsible for
+building up their own timestamp buffer: if they want to be able to send
+multiple `channel_update_2` messages per block, then they will need to ensure 
+that there are blocks during which they do not broadcast any updates. This 
+provides an incentive for nodes not to spam the network with too many updates.
+
+To also prevent nodes from building up too large of a burst-buffer with which 
+they can spam the network and to give a limit to how low the block height on a 
+`node_announcement_2` can be: nodes should not be allowed to use a block height
+smaller 1440 (~ a day worth of blocks) below the current block height.
+
+### Simplifies Channel Announcement Queries
+
+In the legacy gossip protocol, the timestamp of the `channel_announcement` is
+hard to define since the message itself does not have a `timestamp` field. This
+makes timestamp based gossip queries tricky. By using block heights as 
+timestamps instead, there is an implicit timestamp associated with the 
+`channel_announcement_2`: the block in which the funding transaction is mined.
+
+## Bootstrapping Taproot Gossip
+
+While the network upgrades from the legacy gossip protocol to the taproot gossip
+protocol, the following scenarios may exist for any node on the network:
+
+| scenario | has legacy channels | has taproot channels  | should send `node_announcement` | should send `node_announcement_2` |
+|----------|---------------------|-----------------------|---------------------------------|-----------------------------------|
+| 1        | no                  | no                    | no                              | no                                |
+| 2        | yes                 | no                    | yes                             | no                                |
+| 3        | yes                 | yes                   | yes                             | no                                |
+| 4        | no                  | yes                   | no                              | yes                               |
+
+### Scenario 1
+
+These nodes have no announced channels and so should not be broadcasting legacy
+or new node announcement messages.
+
+### Scenario 2
+
+If a node has legacy channels but no taproot channels, they should broadcast
+only a legacy `node_announcement` message. Both taproot-gossip aware and unaware
+nodes will be able to verify the node announcement since both groups are able to
+process the `channel_announcement` for the legacy channel(s). The reason why 
+upgraded nodes should continue to broadcast the legacy announcement is because 
+this is the most effective way of spreading the `option_taproot_gossip` feature 
+bit since un-upgraded nodes can assist in spreading the message. 
+
+### Scenario 3
+
+If a node has both legacy channels and taproot channels, then like Scenario 2 
+nodes, they should continue broadcasting the legacy `node_announcement` 
+message.
+
+### Scenario 4
+
+In this scenario, a node has only taproot channels and no legacy channels. This
+means that they cannot broadcast a legacy `node_announcement` message since 
+un-upgraded nodes will drop this message due to the fact that no legacy 
+`channel_announcement` message would have been received for that node. These 
+nodes will also not be able to use a legacy `node_announcement` to propagate 
+their new `node_announcement_2` message.
+
+### Consideration & Suggestions
+
+While the network is in the upgrade phase, the following suggestions apply:
+
+- Keeping at least a single, announced, legacy channel open during the initial 
+  phase of the transition to the new gossip protocol could be very beneficial 
+  since nodes can continue to broadcast their legacy `node_announcement` and 
+  thus more effectively advertise their support for `option_taproot_gossip`. 
+- Nodes are encouraged to actively connect to other nodes that advertise the 
+  `option_taproot_gossip` feature bit as this is the only way in which they 
+  will learn about taproot channel announcements and updates.
+- Nodes should not use the new `node_announcement_2` message until they have
+  no more announced legacy channels.
+
+### Alternative Approaches
+
+An alternative approach would be to add an optional TLV to the legacy
+`node_annoucement` that includes the serialised `node_announcement_2`. The nice
+thing about this is that it allows the new `node_announcement_2` message to
+propagate quickly through the network before the upgrade is complete. The
+downside of this approach is that it would more than double the size of the
+legacy `node_announcement` and most of the information would be duplicated. It
+also makes gossip queries tricky since `node_announcement_2` uses a block-height
+based timestamp instead of the unix timestamp used by the legacy message.
+There also does not seem to be a big benefit in spreading the 
+`node_announcement_2` message quickly since the speed of propagation of the 
+`channel_announcement_2` and `channel_update_2` messages will still depend on a
+network wide upgrade.
+
+## Specification
+
+### Feature Bits
+
+Unlike the original set of gossip messages, it needs to be explicitly advertised
+that nodes are aware of the new gossip messages defined in this document at
+least until the whole network has upgraded to only using taproot gossip. We thus
+define a new feature bit, `option_taproot_gossip` to be included in the `init`
+message as well as the _old_ `node_announcement` message. Note that for all
+other feature bits with the `N` and `C` contexts, it can be assumed that those
+contexts will switch to the new `node_announcement_2` and
+`channel_announcement_2` messages for all feature bits _except_ for
+`option_taproot_gossip` which only makes sense in the context of the old
+`node_announcement` message and not the new `node_announcement_v2` message.
+The `option_taproot` feature bit can also be implied when using the new taproot 
+gossip messages. 
+
+| Bits  | Name                    | Description                                       | Context | Dependencies     |
+|-------|-------------------------|---------------------------------------------------|---------|------------------|
+| 32/33 | `option_taproot_gossip` | Nodes that understand the taproot gossip messages | IN      | `option_taproot` | 
+
+A node can be assumed to understand the new gossip v2 messages if:
+
+- They advertise `option_taproot_gossip` in a legacy `node_announcement` message
+  OR
+- They have broadcast one of the new gossip messages defined in this document.
+
+Advertisement of the `option_taproot_gossip` feature bit should be taken to 
+mean:
+
+- The node understands and is able to forward all the taproot gossip messages.
+- The node may be willing to open an announced taproot channel.
+
+### `open_channel` Extra Requirements
+
+These extra requirements only apply if the `option_taproot` channel type is set
+in the `open_channel` message.
+
+The sender:
+
+- if `option_taproot_gossip` was negotiated:
+    - MAY set the `announce_channel` bit in `channel_flags`
+- otherwise:
+    - MUST NOT set the `announce_channel` bit.
+
+The receiving node MUST fail the channel if:
+
+- if `option_taproot_gossip` was not negotiated and the `announce_channel`
+  bit in the `channel_flags` was set.
+
+### `channel_ready` Extensions
+
+These extensions only apply if the `option_taproot` channel type was set in the
+`open_channel` message along with the `announce_channel` channel flag.
+
+1. `tlv_stream`: `channel_ready_tlvs`
+2. types:
+   1. type: 0 (`announcement_node_pubnonce`)
+   2. data:
+      * [`66*byte`: `public_nonce`]
+   3. type: 1 (`announcement_bitcoin_pubnonce`)
+   4. data:
+      * [`66*byte`: `public_nonce`]
+   
+### Requirements
+
+The sender: 
+
+  - MUST set the `announcement_node_pubnonce` and 
+    `announcement_bitcoin_pubnonce` tlv fields in `channel_ready`.
+  - SHOULD use the MuSig2 `NonceGen` algorithm to generate two unique secret 
+    nonces and use these to determine the corresponding public nonces: 
+    `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce`.
+  
+The recipient: 
+
+  - MUST fail the channel if: 
+    - if the `announcement_node_pubnonce` or `announcement_bitcoin_pubnonce` tlv 
+      fields are missing.
+    - if the `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce` 
+      are equal.
+    
+### Rationale
+
+The final signature included in the `channel_announcement_v2` message will be a
+single [BIP-340][bip-340] signature that needs to be valid for a public key
+derived by aggregating all the `node_ID` and `bitcoin_key` public keys. The
+signature for this key will thus be created by aggregating (via MuSig2) four
+partial signatures. One for each of the keys: `node_ID_1`, `node_ID_2`, 
+`bitcoin_key_1` and `bitcoin_key_2`. A nonce will need to be generated and
+exchanged for each of the keys and so each node will need to send the other node
+two nonces. The `announcement_node_nonce` is for `node_ID_x` and the 
+`announcement_bitcoin_nonce` is for `bitcoin_key_x`.
+
+Since the channel can only be announced once the `channel_ready` messages have 
+been exchanged and since it is generally preferred to keep nonce exchanges as 
+Just In Time as possible, the nonces are exchanged via the `channel_ready` 
+message.
+
+## The `announcement_signatures_2` Message
+
+Like the legacy `announcement_signatures` message, this is a direct message
+between the two endpoints of a channel and serves as an opt-in mechanism to
+allow the announcement of the channel to the rest of the network. 
+
+1. type: xxx (`announcement_signatures_2`)
+2. data (tlv_stream):
+   1. type: 0 (`channel_id`)
+   2. data:
+       * [`channel_id`:`channel_id`]
+   3. type: 1 (`short_channel_id`)
+   4. data:
+       * [`short_channel_id`:`short_channel_id`]
+   5. type: 2 (`partial_signature`)
+   6. data:
+       * [`partial_signature`:`partial_signature`]
+
+### Requirements
+
+The requirements are similar to the ones defined for the legacy 
+`announcement_signatures`. The below requirements assume that the 
+`option_taproot` channel type was set in `open_channel`.
+
+A node:
+- if the `open_channel` message has the `announce_channel` bit set AND a 
+  `shutdown` message has not been sent:
+  - MUST send the `announcement_signatures_2` message.
+    - MUST NOT send `announcement_signatures_2` messages until `channel_ready` 
+      has been sent and received AND the funding transaction has at least six 
+      confirmations.
+  - MUST set the `partial_signature` field to the 32-byte `s` value of the
+    partial signature calculated as described
+    in [Partial Signature Calculation](#partial-signature-calculation). The
+    message to be signed is
+    `MsgHash("channel_announcement", "announcement_sig", m)` where `m` is the
+    serialisation of the `channel_announcement_2` message excluding the
+    `announcement_sig` field (see the
+    [`MsgHash`](#signature-message-construction) definition).
+- otherwise:
+    - MUST NOT send the `announcement_signatures_2` message.
+- upon reconnection (once the above timing requirements have been met):
+    - MUST respond to the first `announcement_signatures_2` message with its own
+      `announcement_signatures_2` message.
+    - if it has NOT received an `announcement_signatures_2` message:
+        - SHOULD retransmit the `announcement_signatures_2` message.
+
+A recipient node:
+- if the `short_channel_id` is NOT correct:
+    - SHOULD send a `warning` and close the connection, or send an
+      `error` and fail the channel.
+- if the `partial_signature` is NOT valid as
+  per [Partial Signature Verification](#partial-signature-verification):
+    - MAY send a `warning` and close the connection, or send an
+      `error` and fail the channel.
+- if it has sent AND received a valid `announcement_signatures_2` message:
+    - SHOULD queue the `channel_announcement_2` message for its peers.
+- if it has not sent `channel_ready`:
+    - MAY send a `warning` and close the connection, or send an `error` and fail
+      the channel.
+
+### Rationale
+
+The message contains the necessary partial signature, by the sender, that the
+recipient will be able to combine with their own partial signature to construct
+the signature to put in the `channel_announcement_v2` message. Unlike the legacy
+`announcement_signatures` message, `announcement_signatures_v2` only has one
+signature field. This field is a MuSig2 partial signature which is the
+aggregation of the two signatures that the sender would have created (one for
+`bitcoin_key_x` and another for `node_ID_x`).
+
+## The `channel_announcement_2` Message
+
+This gossip message contains ownership information regarding a taproot channel. 
+It ties each on-chain Bitcoin key that makes up the taproot output key to the 
+associated Lightning node key, and vice-versa. The channel is not practically 
+usable until at least one side has announced its fee levels and expiry, using 
+`channel_update_2`.
+
+See [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification)
+for more information regarding the requirements for proving the existence of a
+channel.
+
+1. type: xxx (`channel_announcement_2`)
+2. data: (tlv_stream):
+   1. type: 0 (`announcement_sig`)
+   2. data:
+        * [`bip340_sig`:`bip340_sig`]
+   3. type: 1 (`features`)
+   4. data:
+        * [`...*byte`: `features`]
+   5. type: 2 (`chain_hash`)
+   6. data:
+        * [`chain_hash`:`chain_hash`]
+   7. type: 3 (`short_channel_id`)
+   8. data:
+        * [`short_channel_id`:`short_channel_id`]
+   9. type: 4 (`node_id_1`)
+   10. data:
+        * [`point`:`point`]
+   11. type: 5 (`node_id_2`)
+   12. data:
+       * [`point`:`point`]
+   13. type: 6 (`bitcoin_key_1`)
+   14. data:
+       * [`point`:`point`]
+   15. type: 7 (`bitcoin_key_2`)
+   16. data:
+       * [`point`:`point`]
+
+### Requirements
+
+The origin node:
+
+- MUST include types 0-7.
+- MUST set `chain_hash` to the 32-byte hash that uniquely identifies the chain
+  that the channel was opened within:
+    - for the _Bitcoin blockchain_:
+        - MUST set `chain_hash` value (encoded in hex) equal
+          to `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000`.
+- MUST set `short_channel_id` to refer to the confirmed funding transaction, as
+  specified in [BOLT #2](02-peer-protocol.md#the-channel_ready-message).
+    - Note: the corresponding output MUST be a P2TR, as described
+      in [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification).
+- MUST set `node_id_1` and `node_id_2` to the public keys of the two nodes
+  operating the channel, such that `node_id_1` is the lexicographically-lesser
+  of the two compressed keys sorted in ascending lexicographic order.
+- MUST set `bitcoin_key_1` and `bitcoin_key_2` to `node_id_1` and `node_id_2`'s
+  respective `funding_pubkey`s.
+- MUST set `features` based on what features were negotiated for this channel,
+  according to [BOLT #9](09-features.md#assigned-features-flags)
+- MUST set `announcement_sig` signature to the [BIP-340][bip-340] signature
+  calculated by passing the partial signatures sent and received during the
+  `announcement_signatures_2` exchange to the
+  [MuSig2 PartialSigAgg][musig-partial-sig-agg] function.
+
+The receiving node:
+
+- If types 0-7 are not present:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
+- MUST verify the integrity AND authenticity of the message by verifying the
+  `announcement_sig` as per [BIP 340][bip-340-verify].
+- if there is an unknown even bit in the `features` field:
+    - MUST NOT attempt to route messages through the channel.
+- if the `short_channel_id`'s output does NOT correspond to a P2WSH (using
+  `bitcoin_key_1` and `bitcoin_key_2`, as specified in
+  [BOLT #3](03-transactions.md#funding-transaction-output)) OR the output is
+  spent:
+    - MUST ignore the message.
+- if the specified `chain_hash` is unknown to the receiver:
+    - MUST ignore the message.
+- otherwise:
+    - if `announcement_sig` is invalid OR NOT correct:
+        - SHOULD send a `warning`.
+        - MAY close the connection.
+        - MUST ignore the message.
+    - otherwise:
+        - if `node_id_1` OR `node_id_2` are blacklisted:
+            - SHOULD ignore the message.
+        - otherwise:
+            - if the transaction referred to was NOT previously announced as a
+              channel:
+                - SHOULD queue the message for rebroadcasting.
+                - MAY choose NOT to for messages longer than the minimum
+                  expected length.
+        - if it has previously received a valid `channel_announcement_2`, for
+          the same transaction, in the same block, but for a
+          different `node_id_1` or `node_id_2`:
+            - SHOULD blacklist the previous message's `node_id_1`
+              and `node_id_2`, as well as this `node_id_1` and `node_id_2` AND
+              forget any channels connected to them.
+        - otherwise:
+            - SHOULD store this `channel_announcement_2`.
+- once its funding output has been spent OR reorganized out:
+    - SHOULD forget a channel after a 12-block delay.
+
+### Rationale
+
+Both nodes are required to sign to indicate they are willing to route other
+payments via this channel (i.e. be part of the public network); requiring their
+aggregated MuSig2 Schnorr signature proves that they control the channel.
+
+The blacklisting of conflicting nodes disallows multiple different
+announcements. Such conflicting announcements should never be broadcast by any
+node, as this implies that keys have leaked.
+
+While channels should not be advertised before they are sufficiently deep, the
+requirement against rebroadcasting only applies if the transaction has not moved
+to a different block.
+
+In order to avoid storing excessively large messages, yet still allow for
+reasonable future expansion, nodes are permitted to restrict rebroadcasting
+(perhaps statistically).
+
+New channel features are possible in the future: backwards compatible (or
+optional) features will have _odd_ feature bits, while incompatible features
+will have _even_ feature bits
+(["It's OK to be odd!"](00-introduction.md#glossary-and-terminology-guide)).
+
+A delay of 12-blocks is used when forgetting a channel on funding output spend
+as to permit a new `channel_announcement_2` to propagate which indicates this
+channel was spliced.
+
+## The `node_announcement_2` Message
+
+This gossip message, like the legacy `node_announcement` message, allows a node 
+to indicate extra data associated with it, in addition to its public key. 
+To avoid trivial denial of service attacks, nodes not associated with an already
+known channel (legacy or taproot) are ignored.
+
+Unlike the legacy `node_announcement` message, this message makes use of a 
+Schnorr signature instead of an ECDSA one. This will allow nodes to be backed 
+by multiple keys since MuSig2 can be used to construct the single signature.
+
+The other two main differences from the legacy message are that the timestamp 
+is now a block height and that the message is purely TLV based.
+
+1. type: xxx (`node_announcement_2`)
+2. data: (tlv_stream):
+    1. type: 0 (`announcement_sig`)
+    2. data:
+        * [`bip340_sig`:`bip340_sig`]
+    3. type: 1 (`features`)
+    4. data:
+        * [`...*byte`: `features`]
+    5. type: 2 (`timestamp`)
+    6. data:
+        * [`u32`: `block_height`]
+    7. type: 3 (`node_ID`)
+    8. data: 
+        * [`point`:`node_id`]
+    9. type: 4 (`color`)
+    10. data:
+         * [`rgb_color`:`rgb_color`]
+    11. type: 5 (`alias`)
+    12. data:
+         * [`...*utf8`:`alias`]
+    13. type: 6 (`ipv4_addrs`)
+    14. data: 
+         * [`...*ipv4_addr`: `ipv4_addresses`]  
+    15. type: 7 (`ipv6_addrs`)
+    16. data:
+         * [`...*ipv6_addr`: `ipv6_addresses`]
+    17. type: 8 (`tor_v3_addrs`)
+    18. data: 
+         * [`...*tor_v3_addr`: `tor_v3_addresses`]
+    19. type: 9 (`dns_hostname`)
+    20. data:
+         * [`dns_hostname`: `dns_hostname`]
+
+The following subtypes are defined:
+
+1. subtype: `rgb_color`
+2. data:
+   * [`byte`:`red`]
+   * [`byte`:`green`]
+   * [`byte`:`blue`]
+
+3. subtype: `ipv4_addr`
+4. data:
+    * [`u32`:`addr`]
+    * [`tu16`:`port`]
+
+5. subtype: `ipv6_addr`
+6. data:
+    * [`16*byte`:`addr`]
+    * [`tu16`:`port`]
+ 
+7. subtype: `tor_v3_addr`
+8. data:
+    * [`35*utf8`:`onion_addr`]
+    * [`tu16`:`port`]
+
+9. subtype: `dns_hostname`
+10. data:
+     * [`...*utf8`:`hostname`]
+     * [`tu16`:`port`]
+
+`tor_v3_address` is a Tor version 3 ([prop224]) onion service address;
+Its `onion_addr` encodes:
+`[32:32_byte_ed25519_pubkey] || [2:checksum] || [1:version]`, where
+`checksum = sha3(".onion checksum" | pubkey || version)[:2]`.
+
+The `dns_hostname` `hostname` MUST be ASCII characters. Non-ASCII characters
+MUST be encoded using [Punycode][punycode]. The length of the `hostname` cannot
+exceed 255 bytes.
+
+### Requirements
+
+The sender:
+
+- MUST set types 0-3 (inclusive)
+- MUST set `announcement_sig` to a valid [BIP340][bip-340] signature for the
+  `node_id` key. The message to be signed is
+  `MsgHash("node_announcement_2", "announcement_sig", m)` where `m` is the
+  serialisation of the `node_announcement_2` message excluding the
+  `announcement_sig` field (see the
+  [`MsgHash`](#signature-message-construction) definition).
+- MAY set `color` and `alias` to customise appearance in maps and graphs.
+- If the node sets the `alias`:
+  - MUST use 32 utf8 characters or less. 
+- MUST set `timestamp` to be greater than that of any previous
+  `node_announcement_2` it has previously created.
+    - MUST set it to a block height less than the latest block's height but no
+      more than 1440 lower.
+- If the node wishes to announce its willingness to accept incoming network
+  connections:
+    - SHOULD set at least one of types 7-10.
+- SHOULD set an address type (`ipv4_address`, `ipv6_address`, `tor_v3_address`
+  and/or `dns_hostname`) for each public network address that expects incoming
+  connections.
+- SHOULD ensure that any specified `ipv4_addr` AND `ipv6_addr` are routable
+  addresses.
+- MUST not create a `ipv4_addr`, `ipv6_addr` or `dns_hostname` with a `port`
+  equal to 0.
+- MUST set `features` according to [BOLT #9][bolt-9-features].
+- SHOULD only start using this message once they no longer have announced legacy
+  channels.
+    
+The receiving node:
+
+- If any type between 0-3 (inclusive) are missing:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
+- if `alias` is set and is larger than 32 utf8 characters:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
+- if `node_id` is NOT a valid compressed public key:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST NOT process the message further.
+- if `announcement_sig` is NOT a valid [BIP340][bip-340] signature (using 
+  `node_id` over the message):
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST NOT process the message further.
+- if `features` field contains _unknown even bits_:
+    - SHOULD NOT connect to the node.
+    - Unless paying a [BOLT #11][bolt-11] invoice which does not have the same
+      bit(s) set, MUST NOT attempt to send payments _to_ the node.
+    - MUST NOT route a payment _through_ the node.
+- if `port` is equal to 0 for any `ipv6_addr` OR `ipv4_addr` OR `hostname`:
+    - SHOULD ignore that address.
+- if `node_id` is NOT previously known from a `channel_announcement` OR 
+  `channel_announcement_2` message, OR if `timestamp` is NOT greater than the 
+  last-received `node_announcement_2` from this `node_id`:
+      - SHOULD ignore the message.
+- otherwise:
+    - if `timestamp` is greater than the last-received `node_announcement_2` 
+      from this `node_id`:
+          - SHOULD queue the message for rebroadcasting.
+- MAY use `rgb_color` AND `alias` to reference nodes in interfaces.
+    - SHOULD insinuate their self-signed origins.
+- SHOULD ignore any legacy `node_announcement` message for this `node_ID`.
+
+### Rationale
+
+New node features are possible in the future: backwards compatible (or
+optional) ones will have _odd_ `feature` _bits_, incompatible ones will have
+_even_ `feature` _bits_. These will be propagated normally; incompatible feature
+bits here refer to the nodes, not the `node_announcement_2` message itself.
+
+Since the legacy `node_announcement` uses a UNIX based `timestamp` field and 
+this message uses block heights, deciding which message is the latest one could
+be tricky. To simplify the logic, the decision is made that once a 
+`node_announcement_2` is received, then any legacy `node_announcement` messages 
+received for the same `node_id` can be ignored.
+
+### Security Considerations for Node Aliases
+
+The security considerations for node aliases mentioned in 
+[BOLT #7][bolt-7-alias-security] apply here too.
+
+## The `channel_update_2` Message
+
+After a channel has been initially announced via `channel_announcement_2`, each 
+side independently announces the fees and minimum expiry delta it requires to 
+relay HTLCs through this channel. Each uses the 8-byte short channel id that 
+matches the `channel_announcement_2` and the 1-bit `channel_flags` field to 
+indicate which end of the channel it's on (origin or final). A node can do this 
+multiple times, in order to change fees.
+
+Note that the `channel_update` gossip message is only useful in the context
+of *relaying* payments, not *sending* payments. When making a payment
+`A` -> `B` -> `C` -> `D`, only the `channel_update`s related to channels
+`B` -> `C` (announced by `B`) and `C` -> `D` (announced by `C`) will
+come into play. When building the route, amounts and expiries for HTLCs need
+to be calculated backward from the destination to the source. The exact initial
+value for `amount_msat` and the minimal value for `cltv_expiry`, to be used for
+the last HTLC in the route, are provided in the payment request
+(see [BOLT #11][[bolt-11-tagged-fields]]).
+
+1. type: xxx (`channel_update_2`)
+2. data: (tlv_stream):
+    1. type: 0 (`update_sig`)
+    2. data:
+        * [`bip340_sig`:`bip340_sig`]
+    3. type: 2 (`chain_hash`)
+    4. data:
+        * [`chain_hash`:`chain_hash`]
+    5. type: 2 (`timestamp`)
+    6. data:
+        * [`u32`: `block_height`]
+    7. type: 5 (`channel_flags`)
+    8. data:
+       * [`...*byte`, `channel_flags`]
+    9. type: 6 (`cltv_expiry_delta`)
+    10. data:
+        * [`tu32`, `cltv_expiry_delta`]
+    11. type: 7 (`htlc_min_msat`)
+    12. data: 
+        * [`tu64`, `htlc_min_msat`]
+    13. type: 10 (`htlc_max_msat`)
+    14. data:
+       * [`tu64`, `htlc_max_msat`]
+    15. type: 8 (`fee_base_msat`)
+    16. data:
+       * [`tu32`, `fee_base_msat`]
+    17. type: 9 (`fee_prop_millionths`)
+    18. data:
+      * [`tu32`, `fee_prop_millionths`]
+
+The `channel_flags` bitfield is used to indicate the direction of the channel:
+it identifies the node that this update originated from and signals various
+options concerning the channel. The following table specifies the meaning of its
+individual bits:
+
+| Bit Position | Name        | Meaning                          |
+|--------------|-------------|----------------------------------|
+| 0            | `direction` | Direction this update refers to. |
+| 1            | `disable`   | Disable the channel.             |
+
+The `node_id` for the signature verification is taken from the corresponding
+`channel_announcement_2`: `node_id_1` if the least-significant bit of flags is
+0 or `node_id_2` otherwise.
+
+### Requirements
+
+The origin node:
+- MUST NOT send `channel_update_2` before `channel_ready` has been received. 
+- MUST NOT send `channel_update_2` for legacy (non-taproot) channels.
+- MAY create a `channel_update_2` to communicate the channel parameters to the
+  channel peer, even though the channel has not yet been announced (i.e. the
+  `announce_channel` bit was not set).
+    - MUST set the `short_channel_id` to either an `alias` it has received from
+      the peer, or the real channel `short_channel_id`.
+    - MUST NOT forward such a `channel_update` to other peers, for privacy
+      reasons.
+    - Note: such a `channel_update`, one not preceded by a
+      `channel_announcement`, is invalid to any other peer and would be
+      discarded.
+- MUST set `update_sig` to a valid [BIP340][bip-340] signature for its own
+  `node_id` key. The message to be signed is
+  `MsgHash("channel_update_2", "update_sig", m)` where `m` is the serialisation
+  of the `channel_update` message excluding the `update_sig` field (see the
+  [`MsgHash`](#signature-message-construction) definition).
+- MUST set `chain_hash` AND `short_channel_id` to match the 32-byte hash AND
+  8-byte channel ID that uniquely identifies the channel specified in the
+  `channel_announcement_2` message.
+- if the origin node is `node_id_1` in the message:
+    - MUST set the `direction` bit of `channel_flags` to 0.
+- otherwise:
+    - MUST set the `direction` bit of `channel_flags` to 1.
+- MUST set `htlc_maximum_msat` to the maximum value it will send through this
+  channel for a single HTLC.
+    - MUST set this to less than or equal to the channel capacity.
+    - MUST set this to less than or equal to `max_htlc_value_in_flight_msat` it
+      received from the peer.
+- MAY create and send a `channel_update_2` with the `disable` bit set to 1, to
+  signal a channel's temporary unavailability (e.g. due to a loss of
+  connectivity) OR permanent unavailability (e.g. prior to an on-chain
+  settlement).
+    - MAY send a subsequent `channel_update_2` with the `disable` bit set to 0
+      to re-enable the channel.
+- MUST set `timestamp` greater or equal to the block height that the channel's
+  funding transaction was mined in AND to greater than any previously-sent
+  `channel_update_2` for this `short_channel_id` AND no less than 1440 blocks 
+  below the current best block height . 
+- MUST set `cltv_expiry_delta` to the number of blocks it will subtract from
+  an incoming HTLC's `cltv_expiry`.
+- MUST set `htlc_minimum_msat` to the minimum HTLC value (in millisatoshi)
+  that the channel peer will accept.
+- MUST set `fee_base_msat` to the base fee (in millisatoshi) it will charge
+  for any HTLC.
+- MUST set `fee_proportional_millionths` to the amount (in millionths of a
+  satoshi) it will charge per transferred satoshi.
+- SHOULD NOT create redundant `channel_update_2`s
+- If it creates a new `channel_update_2` with updated channel parameters:
+    - SHOULD keep accepting the previous channel parameters for 10 minutes
+
+The receiving node:
+
+- if the `short_channel_id` does NOT match a previous `channel_announcement_2`,
+  OR if the channel has been closed in the meantime:
+    - MUST ignore `channel_update_2`s that do NOT correspond to one of its own
+      channels.
+- SHOULD accept `channel_update_2`s for its own taproot channels (even if
+  non-public), in order to learn the associated origin nodes' forwarding
+  parameters.
+- if `update_sig` is NOT a valid [BIP340][bip-340] signature (using `node_id`
+  over the message):
+    - SHOULD send a `warning` and close the connection.
+    - MUST NOT process the message further.
+- if the specified `chain_hash` value is unknown (meaning it isn't active on
+  the specified chain):
+    - MUST ignore the channel update.
+- if the `timestamp` is equal to the last-received `channel_update_2` for this
+  `short_channel_id` AND `node_id`:
+    - if the fields below `timestamp` differ:
+        - MAY blacklist this `node_id`.
+        - MAY forget all channels associated with it.
+    - if the fields below `timestamp` are equal:
+        - SHOULD ignore this message
+- if `timestamp` is lower than that of the last-received
+  `channel_update_2` for this `short_channel_id` AND for `node_id`:
+    - SHOULD ignore the message.
+- otherwise:
+    - if the `timestamp` is a block height greater than the current best block
+      height:
+      - MAY discard the `channel_update_2`.
+    - if the `timestamp` block height is more than 1440 blocks less than the 
+      current best block height:
+        - MAY discard the `channel_update_2`.
+    - otherwise:
+        - SHOULD queue the message for rebroadcasting.
+- if `htlc_maximum_msat` is greater than channel capacity:
+    - MAY blacklist this `node_id`
+    - SHOULD ignore this channel during route considerations.
+- otherwise:
+    - SHOULD consider the `htlc_maximum_msat` when routing.
+  
+### Rationale
+
+TODO
+
+## Query Messages
+
+TODO: any updates that need to happen to this section? 
+
+# Appendix A: Algorithms
+
+### Partial Signature Calculation
+
+When both nodes have exchanged `channel_ready` then they will each have the
+following information:
+
+- `node_1` will know:
+    - `bitcoin_priv_key_1`, `node_ID_priv_key_1`,
+    - `bitcoin_key_2`,
+    - `node_ID_1`,
+    - `announcement_node_secnonce_1` and `announcement_node_pubnonce_1`,
+    - `announcement_bitcoin_secnonce_1` and `announcement_bitcoin_pubnonce_1`,
+    - `announcement_node_pubnonce_2`,
+    - `announcement_bitcoin_pubnonce_2`,
+
+- `node_2` will know:
+    - `bitcoin_priv_key_2`, `node_ID_priv_key_2`,
+    - `bitcoin_key_1`,
+    - `node_ID_1`,
+    - `announcement_node_secnonce_2` and `announcement_node_pubnonce_2`,
+    - `announcement_bitcoin_secnonce_2` and `announcement_bitcoin_pubnonce_2`,
+    - `announcement_node_pubnonce_1`,
+    - `announcement_bitcoin_pubnonce_1`,
+
+With the above information, both nodes can now start calculating the partial
+signatures that will be exchanged in the `announcement_signatures_v2` message.
+
+Firstly, the aggregate public key, `P_agg`, that the signature will be valid for
+can be calculated as follows:
+
+```
+P_agg = Musig2.KeyAgg(Musig2.KeySort(node_ID_1, node_ID_2, bitcoin_key_1, bitcoin_key_2))
+```
+
+Next, the aggregate public nonce, `aggnonce`, can be calculated:
+
+```
+aggnonce = Musig2.NonceAgg(announcement_node_secnonce_1, announcement_bitcoin_pubnonce_1, announcement_node_secnonce_2, announcement_bitcoin_pubnonce_2)
+```
+
+The message, `msg` that the peers will sign is the serialisation of
+`channel_announcement_2` _without_ the `announcement_sig` field (i.e. without
+type 0)
+
+With all the information mentioned, both peers can now construct the
+[`Session Context`][musig-session-ctx] defined by the MuSig2 protocol which is
+necessary for as an input to the `Musig2.Sign` algorithm. The following members
+of the `Session Context`, which we will call `session_ctx`, can be defined:
+
+- `aggnonce`: `aggnonce`
+- `u`: 2
+- `pk1..u`: [`node_ID_1`, `node_ID_2`, `bitcoin_key_1`, `bitcoin_key_2`]
+- `v`: 0
+- `m`: `msg`
+
+Both peers, `node_1` and `node_2` will need to construct two partial signatures.
+One for their `bitcoin_key` and one for their `node_ID` and aggregate those.
+
+- `node_1`:
+    - calculates a partial signature for `node_ID_1` as follows:
+       ```
+       partial_sig_node_1 = MuSig2.Sign(announcement_node_secnonce_1, node_ID_priv_key_1, session_ctx) 
+       ```
+    - calculates a partial signature for `bitcoin_ID_1` as follows:
+       ```
+       partial_sig_bitcoin_1 = MuSig2.Sign(announcement_bitcoin_secnonce_1, bitcoin_priv_key_1, session_ctx) 
+       ```
+    - calculates `partial_sig_1` as follows:
+       ```
+       partial_sig_1 =  MuSig2.PartialSigAgg(partial_sig_node_1, partial_sig_bitcoin_1, session_ctx)
+       ```
+
+- `node_2`:
+    - calculates a partial signature for `node_ID_2` as follows:
+       ```
+       partial_sig_node_2 = MuSig2.Sign(announcement_node_secnonce_2, node_ID_priv_key_2, session_ctx) 
+       ```
+    - calculates a partial signature for `bitcoin_ID_2` as follows:
+       ```
+       partial_sig_bitcoin_2 = MuSig2.Sign(announcement_bitcoin_secnonce_2, bitcoin_priv_key_2, session_ctx) 
+       ```
+    - calculates `partial_sig_2` as follows:
+       ```
+       partial_sig_2 =  MuSig2.PartialSigAgg(partial_sig_node_2, partial_sig_bitcoin_2, session_ctx)
+       ```     
+
+Note that since there are no tweaks involved in this MuSig2 signing flow,
+signature aggregation is simply the addition of the two signatures:
+
+```
+    partial_sig = (partial_sig_node + partial_sig_bitcoin) % n
+```
+
+Where `n` is the [secp256k1][secp256k1] curve order.
+
+### Partial Signature Verification
+
+Since the partial signature put in `announcement_signatures_2` is the addition
+of two of four signatures required to make up the final MuSig2 signature, the
+verification of the partial signature is slightly different from what is
+specified in the MuSig2 spec. The slightly adjusted algorithm will be defined
+here. The notation used is the same as defined in the [MuSig2][musig-notation]
+spec.
+
+The inputs are:
+
+- `partial_sig` sent by the peer in the `announcement_signatures_2` message.
+- The `node_ID` and `bitcoin_key` of the peer.
+- The `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce` sent by
+  the peer in the `channel_ready` message.
+- The `session_ctx` as shown
+  in [Partial Signature Calculation](#partial-signature-calculation).
+
+Verification steps:
+
+Note that the `GetSessionValues` and `GetSessionKeyAggCoeff` definitions can be
+found in the [MuSig2][musig-session-ctx] spec.
+
+- Let `(Q, _, _, b, R, e) = GetSessionValues(session_ctx)`
+- Let `s = int(psig); fail if s >= n`
+- Let `R_n1 = cpoint(announcement_node_pubnonce[0:33])`
+- Let `R_n2 = cpoint(announcement_node_pubnonce[33:66])`
+- Let `R_b1 = cpoint(announcement_bitcoin_pubnonce[0:33])`
+- Let `R_b2 = cpoint(announcement_bitcoin_pubnonce[33:66])`
+- Let `R_1 = R_n1 + R_b1`
+- Let `R_2 = b*(R_n2 + R_b2)`
+- Let `R_e' = R_1 + R_2`
+- Let `R_e = R_e'` if `has_even_y(R)`, otherwise let `R_e = -R_e'`
+- Let `P_n = node_ID`
+- Let `P_b = bitcoin_key`
+- Let `a_n = GetSessionKeyAggCoeff(session_ctx, P_n)`
+- Let `a_b = GetSessionKeyAggCoeff(session_ctx, P_b)`
+- Let `P = a_n*P_n + a_b*P_b`
+- Let `g = 1` if `has_even_y(Q)`, otherwise `let g = -1 mod n`
+- Fail if `s*G != R_e + e*g*P`
+
+### Signature Message Construction
+
+The following `MsgHash` function is defined which can be used to construct a
+32-byte message that can be used as a valid input to the [BIP-340][bip-340]
+signing and verification algorithms.
+
+_MsgHash:_
+  - _inputs_:
+    * `message_name`: UTF-8 string
+    * `field_name`: UTF-8 string
+    * `message`: byte array
+
+  - Let `tag` = "lightning" || `message_name` || `field_name`
+  - return SHA256(SHA256(`tag`) || SHA256(`tag`) || SHA256(`message`))
+
+
+# Appendix B: Test Vectors
+
+TODO(elle)
+
+# Acknowledgements
+
+The ideas in this document are largely a consolidation and filtering of the
+ideas mentioned in the following references:
+
+- [Rusty's initial Gossip v2 proposal][ml-rusty-2019-gossip-v2] where the idea
+  of replacing all gossip messages with new ones that use Schnorr signatures was
+  first mentioned (in public writing). This post also included the idea of using
+  block heights instead of Unix timestamps for timestamp fields as well as the
+  idea of moving some optional fields to TLVs.
+- [Roasbeef's post][ml-roasbeef-2022-tr-chan-announcement] on Taproot-aware
+  Channel Announcements + Proof Verification which expands on the details of how
+  taproot channel verification should work.
+
+[bolt-7]: ./07-routing-gossip.md
+[bolt-7-alias-security]: ./07-routing-gossip.md#security-considerations-for-node-aliases
+[bolt-9-features]: ./09-features.md#bolt-9-assigned-feature-flags
+[bolt-11]: ./11-payment-encoding.md
+[bolt-11-tagged-fields]: ./11-payment-encoding.md#tagged-fields
+[open-chan-msg]: ./02-peer-protocol.md#the-open_channel-message
+[ml-rusty-2019-gossip-v2]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-July/002065.html
+[ml-roasbeef-2022-tr-chan-announcement]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2022-March/003526.html
+[bip-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+[bip-340-verify]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#verification
+[simple-taproot-chans]: https://github.com/lightning/bolts/pull/995
+[musig-keysort]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#key-sorting
+[musig-keyagg]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#key-aggregation
+[musig-signing]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#signing
+[bip86-tweak]: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#address-derivation
+[bip-musig2]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki
+[musig-session-ctx]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#session-context
+[musig-notation]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#notation
+[musig-partial-sig-agg]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#partial-signature-aggregation
+[secp256k1]: https://www.secg.org/sec2-v2.pdf
+[punycode]: https://en.wikipedia.org/wiki/Punycode
+[prop224]: https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -1,60 +1,40 @@
 # Extension BOLT XX: Taproot Gossip
 
-# Table of Contents
-
-  * [Aim](#aim)
-  * [Overview](#overview)
-  * [Terminology](#terminology)
-  * [Type Definitions](#type-definitions)
-  * [TLV Based Messages](#tlv-based-messages)
-  * [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification)
-  * [Timestamp fields](#timestamp-fields)
-  * [Bootstrapping Taproot Gossip](#bootstrapping-taproot-gossip)
-  * [Specification](#specification)
-    * [Feature Bits](#feature-bits)
-    * [The `announcement_signatures_2` message](#the-announcement_signatures_2-message)
-    * [The `channel_announcement_2` message](#the-channel_announcement_2-message)
-    * [The `node_announcement_2` message](#the-node_announcement_2-message)
-    * [The `channel_update_2` message](#the-channel_update_2-message)
-  * [Appendix A: Algorithms](#appendix-a-algorithms)
-      * [Partial Signature Calculation](#partial-signature-calculation)
-      * [Partial Signature Verification](#partial-signature-verification)
-  * [Appendix B: Test Vectors](#appendix-b-test-vectors)
-  * [Acknowledgements](#acknowledgements)
-
-## Aim 
-
 This document aims to update the gossip protocol defined in [BOLT 7][bolt-7] to
 allow for advertisement and verification of taproot channels. An entirely new
 set of gossip messages are defined that use [BIP-340][bip-340] signatures and
-that use a purely TLV based schema.
+that use a mostly TLV based structure.
 
-## Overview
+# Table Of Contents
 
-The initial version of the Lightning Network gossip protocol as defined in
-[BOLT 7][bolt-7] was designed around P2WSH funding transactions. For these
-channels, the `channel_announcement` message is used to advertise the channel to
-the rest of the network. Nodes in the network use the content of this message to
-prove that the channel is sufficiently bound to the Lightning Network context
-by being provided enough information to prove that the script is a 2-of-2 
-multi-sig and that it is owned by the nodes advertising the channel. This 
-ownership proof is done by including signatures in the `channel_announcement` 
-from both the node ID keys along with the bitcoin keys used in the P2WSH script. 
-This proof and verification protocol is, however, not compatible with SegWit V1 
-(P2TR) outputs and so cannot be used to advertise the channels defined in the 
-[Simple Taproot Channel][simple-taproot-chans] proposal. This document thus aims 
-to define an updated gossip protocol that will allow nodes to both advertise and 
-verify taproot channels. This part of the update affects the 
-`announcement_signatures` and `channel_announcement` messages.
-
-The opportunity is also taken to rework the `node_announcement` and
-`channel_update` messages to take advantage of [BIP-340][bip-340] signatures and
-TLV fields. Timestamp fields are also updated to be block heights instead of
-Unix timestamps.
+* [Terminology](#terminology)
+* [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification)
+* [TLV Based Messages](#tlv-based-messages)
+* [Block-height fields](#block-height-fields)
+* [Bootstrapping Taproot Gossip](#bootstrapping-taproot-gossip)
+* [Specification](#specification)
+    * [Type Definitions](#type-definitions)
+    * [Features Bits](#feature-bits)
+    * [Features Bit Contexts](#feature-bit-contexts)
+    * [`open_channel` Extra Requirements](#openchannel-extra-requirements)
+    * [`channel_ready` Extensions](#channelready-extensions)
+    * [The `announcement_signatures_2` Message](#the-announcementsignatures2-message)
+    * [The `channel_announcement_2` Message](#the-channelupdate2-message)
+    * [The `node_announcement_2` Message](#the-nodeannouncement2-message)
+    * [The `channel_update_2` Message](#the-channelupdate2-message)
+* [Appendix A: Algorithms](#appendix-a-algorithms)
+    * [Partial Signature Calculation](#partial-signature-calculation)
+    * [Partial Signature Verification](#partial-signature-verification)
+    * [Verifying the `channel_announcement_2` signature](#verifying-the-channelannouncement2-signature)
+        * [The 3-of-3 MuSig2 Scenario](#the-3-of-3-musig2-scenario)
+        * [The 4-of-4 MuSig2 Scenario](#the-4-of-4-musig2-scenario)
+    * [Signature Message Construction](#signature-message-construction)
+* [Appendix B: Test Vectors](#appendix-b-test-vectors)
+* [Acknowledgements](#acknowledgements)
 
 ## Terminology
 
-- Collectively, the set of new gossip messages will be referred to as 
+- Collectively, the set of new gossip messages will be referred to as
   `taproot gossip`.
 - `node_1` and `node_2` refer to the two parties involved in opening a channel.
 - `node_ID_1` and `node_ID_2` respectively refer to the public keys that
@@ -63,7 +43,214 @@ Unix timestamps.
   that `node_1` and `node_2` will use for the specific channel being opened.
   The funding transaction's output will be derived from these two keys.
 
-## Type Definitions
+## Taproot Channel Proof and Verification
+
+All Taproot channel funding transaction outputs are SegWit V1 (P2TR) outputs of
+the following form:
+
+```
+OP_1 <taproot_output_key> 
+```
+
+Ideally, the construction of the `taproot_output_key` should not matter to a
+verifier of a channel. What a verifier cares about is whether the UTXO is
+unspent and if the associated channel announcement contains a signature that
+proves that the owner of the UTXO has participated in the signature
+construction.
+
+The simplest verification of a channel-announcement signature would then be to
+check that the signature is valid for the following aggregate 3-of-3 MuSig2
+public key:
+
+```
+P_agg = MuSig2.KeyAgg(MuSig2.KeySort(node_id_1, node_id_2, taproot_output_key))
+```
+
+This is simple and the spec can cater for this verification method today.
+However, the spec must also contain recommendations for the construction of a
+channel along with recommendations for the construction of a channel
+announcement signature. The `taproot_output_key` will most likely be constructed
+out of two or more keys where both channel peers own at least one key each and
+so to compute a valid signature for the `P_agg` key noted above, the two channel
+parties would need to make use of a nested MuSig2 protocol. Such a protocol has
+yet to be specified and so this document can not yet rely on or reference such
+a protocol.
+
+Therefore, this document will also cater for the verification and construction
+of a channel announcement signature for the following 4-of-4 MuSig2 public key:
+
+```
+P_agg = MuSig2.KeyAgg(MuSig2.KeySort(node_id_1, node_id_2, bitcoin_key_1, bitcoin_key_2))
+```
+
+In this case, the `taproot_output_key` is expected to be constructed in one of
+two ways. The first way is as a pure key path spend output as follows:
+
+```
+taproot_output_key = MuSig2.KeyAgg(MuSig2.KeySort(bitcoin_key_1, bitcoin_key_2))
+```
+
+The second way includes a possible tweak:
+
+```
+taproot_internal_key = MuSig2.KeyAgg(MuSig2.KeySort(bitcoin_key_1, bitcoin_key_2))
+
+taproot_output_key = taproot_internal_key + tagged_hash("TapTweak", merkle_root_hash) * G
+```
+
+In the case of Simple Taproot Channels, the `merkle_root_hash` will be equal to
+the serialisation of the `taproot_internal_key`.
+
+The verification method used all depends on which information is provided in the
+`channel_announcement_2` message. All of these verification methods require
+the `node_id_1` and `node_id_2` to be provided along with a `short_channel_id`
+that will allow the verifier to fetch the funding output from which the
+`taproot_output_key` can be extracted.
+
+1. If no bitcoin keys are provided, then the signature must be verified against
+   the following public key:
+
+   ```
+   P_agg = MuSig2.KeyAgg(MuSig2.KeySort(node_id_1, node_id_2, taproot_output_key)) 
+   ```
+
+   Allowing this proof type allows nodes to be somewhat future-proof since they
+   will be able to verify and make use of channels using a proof construction
+   not yet defined.
+
+2. If the two bitcoin keys (`bitcoin_key_1` and `bitcoin_key_2`) are provided
+   but no `merkle_root_hash` is provided then the verification steps are as
+   follows:
+
+    1. Compute the following aggregate 2-of-2 MuSig2 public key:
+       ```
+       P_agg_out = MuSig2.KeyAgg(MuSig2.KeySort(bitcoin_key_1, bitcoin_key_2))
+       ```
+    2. Assert that `P_agg_out` is equal to `taproot_output_key`.
+    3. Now, compute the following aggregate 4-of-4 MuSig2 public key:
+       ```
+       P_agg = MuSig2.KeyAgg(MuSig2.KeySort(node_id_1, node_id_2, bitcoin_key_1, bitcoin_key_2))
+       ```
+    4. The signature must then be verified against `P_agg`.
+
+3. If the two bitcoin keys and the `merkle_root_hash` is provided, then the
+   verification steps are as follows:
+
+    1. Compute the following aggregate 2-of-2 MuSig2 public key:
+       ```
+       P_internal = MuSig2.KeyAgg(MuSig2.KeySort(bitcoin_key_1, bitcoin_key_2))
+       ``` 
+    2. The compute the following output public key:
+       ```
+       P_output = P_internal + tagged_hash("TapTweak", merkle_root_hash) * G
+       ```
+    3. Assert that `P_output` is equal to `taproot_output_key`.
+    4. Now, compute the following aggregate 4-of-4 MuSig2 public key:
+       ```
+       P_agg = MuSig2.KeyAgg(MuSig2.KeySort(node_id_1, node_id_2, bitcoin_key_1, bitcoin_key_2))
+       ```
+    5. The signature must then be verified against `P_agg`.
+
+In terms of construction of the proofs, this document covers case 2 and 3.
+
+## TLV Based Messages
+
+The initial set of Lightning Network messages consisted of a flat set of
+serialised fields that were mandatory. Later on, TLV encoding was introduced
+which provided a backward compatible way to extend messages. To ensure that the
+new messages defined in this document remain as future-proof as possible, the
+messages will mostly be pure TLV streams with a fixed 64-byte signature over the
+tlv stream appended at the front of the message. By making all fields in the
+messages TLV records, fields that we consider mandatory today can easily be
+dropped in future (when coupled with a new feature bit) without needing to
+completely redefine the gossip message in order to make the field optional.
+
+## Block-height fields
+
+In the messages defined in this document, block heights are used as timestamps
+instead of the UNIX timestamps used in the legacy set of gossip messages.
+
+### Rate Limiting
+
+A block height based timestamp results in more natural rate limiting for gossip
+messages: nodes are allowed to send at most one announcement and update per
+block. To allow for bursts, nodes are encouraged not to use the latest block
+height for their latest announcements/updates but rather to backdate and use
+older block heights that they have not used in an announcement/update. There of
+course needs to be a limit on the start block height that the node can use:
+for `channel_update_2` messages, the first `blockheight` must be the block
+height in which the channel funding transaction was mined and all updates after
+the initial one must have increasing block heights. Nodes are then responsible
+for building up their own timestamp buffer: if they want to be able to send
+multiple `channel_update_2` messages per block, then they will need to ensure
+that there are blocks during which they do not broadcast any updates. This
+provides an incentive for nodes not to spam the network with too many updates.
+
+TODO:
+- how do we choose a minimum block-height for `node_announcement_2`?
+
+### Simplifies Channel Announcement Queries
+
+In the legacy gossip protocol, the timestamp of the `channel_announcement` is
+hard to define since the message itself does not have a `timestamp` field. This
+makes timestamp based gossip queries tricky. By using block heights as
+timestamps instead, there is an implicit timestamp associated with the
+`channel_announcement_2`: the block in which the funding transaction is mined.
+
+## Bootstrapping Taproot Gossip
+
+While the network upgrades from the legacy gossip protocol to the taproot gossip
+protocol, the following scenarios may exist for any node on the network:
+
+| scenario | has legacy channels | has taproot channels  | should send `node_announcement` | should send `node_announcement_2` |
+|----------|---------------------|-----------------------|---------------------------------|-----------------------------------|
+| 1        | no                  | no                    | no                              | no                                |
+| 2        | yes                 | no                    | yes                             | ?                                 |
+| 3        | yes                 | yes                   | yes                             | ?                                 |
+| 4        | no                  | yes                   | no                              | yes                               |
+
+### Scenario 1
+
+These nodes have no announced channels and so should not be broadcasting legacy
+or new node announcement messages.
+
+### Scenario 2
+
+If a node has legacy channels but no taproot channels, they should continue to
+broadcast the legacy `node_announcement` message so that un-upgraded nodes can
+continue to receive `node_annoucement`s from these nodes which will initially
+also be the most effective way to spread the `option_taproot_gossip` feature
+bit to the rest of the network which will then allow upgraded nodes to find
+each-other.
+
+TODO: should these nodes also send the new node announcement? if so:
+- how do we deal with differences in the two announcements?
+- also, how does a receiving node confirm which announcement is the latest
+one given that they don't use the same timestamp type?
+
+### Scenario 3
+
+Similar to scenario 2.
+
+### Scenario 4
+
+If a node has no more legacy channels, then it will not be able to advertise
+a legacy `node_announcement` since un-upgraded nodes will drop the announcements
+due to no open channel will be known for that node. So in this case, only a
+new `node_announcement_2` can be used.
+
+### Considerations & Suggestions
+
+While the network is in the upgrade phase, the following suggestions apply:
+
+- Nodes are encouraged to actively connect to other nodes that advertise the
+  `option_taproot_gossip` feature bit as this is the only way in which they
+  will learn about taproot channel announcements and updates. This should be
+  done while taking care not to split the network.
+
+## Specification
+
+### Type Definitions
 
 The following convenient types are defined:
 
@@ -75,213 +262,30 @@ The following convenient types are defined:
 * `utf8`: a byte as part of a UTF-8 string. A writer MUST ensure an array of
   these is a valid UTF-8 string, a reader MAY reject any messages containing an
   array of these which is not a valid UTF-8 string.
-
-## TLV Based Messages
-
-The initial set of Lightning Network messages consisted of fields that had to 
-be present. Later on, TLV encoding was introduced which provided a backward 
-compatible way to extend messages. To ensure that the new messages defined in 
-this document remain as future-proof as possible, the messages will be pure TLV
-streams. By making all fields in the messages TLV records, fields that we
-consider mandatory today can easily be dropped in future (when coupled with a 
-new feature bit) without needing to completely redefine the gossip message in 
-order to make the field optional.
-
-## Taproot Channel Proof and Verification
-
-Taproot channel funding transaction outputs will be SegWit V1 (P2TR) outputs of
-the following form:
-
-```
-OP_1 <taproot_output_key> 
-```
-
-where 
-```
-taproot_internal_key = MuSig2.KeyAgg(MuSig2.KeySort(bitcoin_key_1, bitcoin_key_2))
-
-taproot_output_key = taproot_internal_key + tagged_hash("TapTweak", taproot_internal_key) * G
-```
-
-`taproot_interal_key` is the aggregate key of `bitcoin_key_1` and
-`bitcoin_key_2` after first sorting the keys using the
-[MuSig2 KeySort][musig-keysort] algorithm and then running the
-[MuSig2 KeyAgg][musig-keyagg] algorithm.
-
-Then, to commit to spending the taproot output via the keyspend path, a
-[BIP86][bip86-tweak] tweak is added to the internal key to calculate the
-`taproot_output_key`.
-
-As with legacy channels, nodes will want to perform some checks before adding 
-an announced taproot channel to their routing graph:
-
-1. The funding output of the channel being advertised exists on-chain, is an
-   unspent UTXO and has a sufficient number of confirmations. To allow this 
-   check, the SCID of the channel will continue to be included in the channel
-   announcement.
-2. The funding transaction is sufficiently bound to the Lightning context. 
-   Nodes will do this by checking that they are able to derive the output key 
-   found on-chain by using the advertised `bitcoin_key_1` and `bitcoin_key_2` 
-   along with a [BIP86 tweak][bip86-tweak]. This provides a slightly weaker
-   binding to the LN context than legacy channels do but at least somewhat 
-   limits how the output can be spent due to the script-path being disabled.
-   The context binding with legacy channels is greater because an attacker 
-   trying to create gossip spam would need to create 2-of-2 multisig P2WSH 
-   outputs on-chain that would require them to then pay for the bytes of two
-   signatures at the time of spending the output. This extra cost provided some
-   extra deterrence for attackers. This deterrence is not present with P2TR 
-   transactions.
-3. The owners of `bitcoin_key_1` and `bitcoin_key_2` agree to be associated with  
-   a channel owned by `node_1` and `node_2`.
-4. The owners of `node_ID_1` and `node_ID_2` agree to being associated with the 
-   output paying to `bitcoin_key_1` and `bitcoin_key_2`. 
-
-For legacy channels, these last two proofs are made possible by including four
-separate signatures in the `channel_announcement`. However, [BIP-340][bip-340]
-signatures and the MuSig2 protocol allow us to now aggregate these four
-signatures into a single one. Verifiers will then be able to aggregate the four
-keys (`bitcoin_key_1`, `bitcoin_key_2`, `node_ID_1` and `node_ID_2`) using
-MuSig2 key aggregation, and then they can do a single signature verification
-check instead of four individual checks.
-
-## Block-height fields
-
-In the messages defined in this document, block heights are used as timestamps
-instead of the UNIX timestamps used in the legacy set of gossip messages. 
-
-### Rate Limiting
-
-A block height based timestamp results in more natural rate limiting for gossip
-messages: nodes are allowed to send at most one announcement and update per
-block. To allow for bursts, nodes are encouraged not to use the latest block
-height for their latest announcements/updates but rather to backdate and use
-older block heights that they have not used in an announcement/update. There of
-course needs to be a limit on the start block height that the node can use:
-for `channel_update_2` messages, the first timestamp must be the block height in
-which the channel funding transaction was mined and all updates after the
-initial one must have increasing timestamps. Nodes are then responsible for
-building up their own timestamp buffer: if they want to be able to send
-multiple `channel_update_2` messages per block, then they will need to ensure 
-that there are blocks during which they do not broadcast any updates. This 
-provides an incentive for nodes not to spam the network with too many updates.
-
-To also prevent nodes from building up too large of a burst-buffer with which 
-they can spam the network and to give a limit to how low the block height on a 
-`node_announcement_2` can be: nodes should not be allowed to use a block height
-smaller 2016 (~ one week worth of blocks) below the current block height.
-
-### Simplifies Channel Announcement Queries
-
-In the legacy gossip protocol, the timestamp of the `channel_announcement` is
-hard to define since the message itself does not have a `timestamp` field. This
-makes timestamp based gossip queries tricky. By using block heights as 
-timestamps instead, there is an implicit timestamp associated with the 
-`channel_announcement_2`: the block in which the funding transaction is mined.
-
-## Bootstrapping Taproot Gossip
-
-While the network upgrades from the legacy gossip protocol to the taproot gossip
-protocol, the following scenarios may exist for any node on the network:
-
-| scenario | has legacy channels | has taproot channels  | should send `node_announcement` | should send `node_announcement_2` |
-|----------|---------------------|-----------------------|---------------------------------|-----------------------------------|
-| 1        | no                  | no                    | no                              | no                                |
-| 2        | yes                 | no                    | yes                             | no                                |
-| 3        | yes                 | yes                   | yes                             | no                                |
-| 4        | no                  | yes                   | no                              | yes                               |
-
-### Scenario 1
-
-These nodes have no announced channels and so should not be broadcasting legacy
-or new node announcement messages.
-
-### Scenario 2
-
-If a node has legacy channels but no taproot channels, they should broadcast
-only a legacy `node_announcement` message. Both taproot-gossip aware and unaware
-nodes will be able to verify the node announcement since both groups are able to
-process the `channel_announcement` for the legacy channel(s). The reason why 
-upgraded nodes should continue to broadcast the legacy announcement is because 
-this is the most effective way of spreading the `option_taproot_gossip` feature 
-bit since un-upgraded nodes can assist in spreading the message. 
-
-### Scenario 3
-
-If a node has both legacy channels and taproot channels, then like Scenario 2 
-nodes, they should continue broadcasting the legacy `node_announcement` 
-message.
-
-### Scenario 4
-
-In this scenario, a node has only taproot channels and no legacy channels. This
-means that they cannot broadcast a legacy `node_announcement` message since 
-un-upgraded nodes will drop this message due to the fact that no legacy 
-`channel_announcement` message would have been received for that node. These 
-nodes will also not be able to use a legacy `node_announcement` to propagate 
-their new `node_announcement_2` message.
-
-### Considerations & Suggestions
-
-While the network is in the upgrade phase, the following suggestions apply:
-
-- Keeping at least a single, announced, legacy channel open during the initial 
-  phase of the transition to the new gossip protocol could be very beneficial 
-  since nodes can continue to broadcast their legacy `node_announcement` and 
-  thus more effectively advertise their support for `option_taproot_gossip`. 
-- Nodes are encouraged to actively connect to other nodes that advertise the 
-  `option_taproot_gossip` feature bit as this is the only way in which they 
-  will learn about taproot channel announcements and updates.
-- Nodes should not use the new `node_announcement_2` message until they have
-  no more announced legacy channels.
-
-### Alternative Approaches
-
-An alternative approach would be to add an optional TLV to the legacy
-`node_annoucement` that includes the serialised `node_announcement_2`. The nice
-thing about this is that it allows the new `node_announcement_2` message to
-propagate quickly through the network before the upgrade is complete. The
-downside of this approach is that it would more than double the size of the
-legacy `node_announcement` and most of the information would be duplicated. It
-also makes gossip queries tricky since `node_announcement_2` uses a block-height
-based timestamp instead of the unix timestamp used by the legacy message.
-There also does not seem to be a big benefit in spreading the 
-`node_announcement_2` message quickly since the speed of propagation of the 
-`channel_announcement_2` and `channel_update_2` messages will still depend on a
-network wide upgrade.
-
-## Specification
+* `boolean_tlv`: a zero length TLV record. If the TLV is present then true is
+  implied, otherwise false is implied.
 
 ### Feature Bits
 
-Unlike the original set of gossip messages, it needs to be explicitly advertised
-that nodes are aware of the new gossip messages defined in this document at
-least until the whole network has upgraded to only using taproot gossip. We thus
-define a new feature bit, `option_taproot_gossip` to be included in the `init`
-message as well as the _old_ `node_announcement` message. Note that for all
-other feature bits with the `N` and `C` contexts, it can be assumed that those
-contexts will switch to the new `node_announcement_2` and
-`channel_announcement_2` messages for all feature bits _except_ for
-`option_taproot_gossip` which only makes sense in the context of the old
-`node_announcement` message and not the new `node_announcement_v2` message.
-The `option_taproot` feature bit can also be implied when using the new taproot 
-gossip messages. 
+A new feature bit, `option_taproot_gossip`, is introduced. Nodes can use this
+feature bit in the `init` and _legacy_ `node_announcement` messages to advertise
+that they understand the new set of taproot gossip messages and that will
+therefore be able to route over Taproot Channels. If a node advertises
+both the `option_taproot_gossip`  _and_ the `option_taproot` feature bits, then
+that node has the ability to open and announce a Simple Taproot Channel.
 
-| Bits  | Name                    | Description                                       | Context | Dependencies     |
-|-------|-------------------------|---------------------------------------------------|---------|------------------|
-| 32/33 | `option_taproot_gossip` | Nodes that understand the taproot gossip messages | IN      | `option_taproot` | 
+| Bits  | Name                    | Description                               | Context | Dependencies |
+|-------|-------------------------|-------------------------------------------|---------|--------------|
+| 32/33 | `option_taproot_gossip` | Node understands taproot gossip messages  | IN      |              | 
 
-A node can be assumed to understand the new gossip v2 messages if:
+### Feature Bit Contexts
 
-- They advertise `option_taproot_gossip` in the `init` or 
-  legacy `node_announcement` messages
-  OR
-- They have broadcast one of the new gossip messages defined in this document.
-
-Advertisement of the `option_taproot_gossip` feature bit should be taken to 
-mean:
-
-- The node understands and is able to forward all the taproot gossip messages.
-- The node may be willing to open an announced taproot channel.
+For all feature bits other than `option_taproot_gossip` defined in
+[Bolt 9][bolt-9-features] with the `N` and `C` contexts, it can be assumed that
+those contexts will now refer to the new `node_announcement_2` and
+`channel_announcement_2` messages defined in this document. The
+`option_taproot_gossip` feature bit only makes sense in the context of the
+legacy messages since it can be implied with the new taproot gossip messages.
 
 ### `open_channel` Extra Requirements
 
@@ -289,16 +293,14 @@ These extra requirements only apply if the `option_taproot` channel type is set
 in the `open_channel` message.
 
 The sender:
-
 - if `option_taproot_gossip` was negotiated:
     - MAY set the `announce_channel` bit in `channel_flags`
 - otherwise:
     - MUST NOT set the `announce_channel` bit.
 
-The receiving node MUST fail the channel if:
-
-- if `option_taproot_gossip` was not negotiated and the `announce_channel`
-  bit in the `channel_flags` was set.
+The receiver:
+- if `option_taproot_gossip` was not negotiated and the `announce_channel` bit
+  in `channel_flags` was set, MUST fail the channel.
 
 ### `channel_ready` Extensions
 
@@ -307,92 +309,100 @@ These extensions only apply if the `option_taproot` channel type was set in the
 
 1. `tlv_stream`: `channel_ready_tlvs`
 2. types:
-   1. type: 0 (`announcement_node_pubnonce`)
-   2. data:
-      * [`66*byte`: `public_nonce`]
-   3. type: 2 (`announcement_bitcoin_pubnonce`)
-   4. data:
-      * [`66*byte`: `public_nonce`]
-   
-### Requirements
+    1. type: 0 (`announcement_node_pubnonce`)
+    2. data:
+        * [`66*byte`: `public_nonce`]
+    3. type: 2 (`announcement_bitcoin_pubnonce`)
+    4. data:
+        * [`66*byte`: `public_nonce`]
 
-The sender: 
+#### Requirements
 
-  - MUST set the `announcement_node_pubnonce` and 
-    `announcement_bitcoin_pubnonce` tlv fields in `channel_ready`.
-  - SHOULD use the MuSig2 `NonceGen` algorithm to generate two unique secret 
-    nonces and use these to determine the corresponding public nonces: 
-    `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce`.
-  
-The recipient: 
+The sender:
 
-  - MUST fail the channel if: 
-    - if the `announcement_node_pubnonce` or `announcement_bitcoin_pubnonce` tlv 
-      fields are missing.
-    - if the `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce` 
-      are equal.
-    
-### Rationale
+- MAY send `channel_ready` message without the `announcement_node_pubnonce` and
+  `announcement_bitcoin_pubnonce` fields.
+- Once the channel is ready to be announced, the node:
+    - SHOULD send `channel_ready` with the `announcement_node_pubnonce` and
+      `announcement_bitcoin_pubnonce` fields set. The `announcement_node_pubnonce`
+      must be set to the public nonce to be used for signing with the node's
+      bitcoin key and the `announcement_bitcoin_pubnonce` must be set to the
+      public nonce to be used for signing with the node's node ID key.
+    - Upon reconnection, if a fully signed `channel_announcement_2` has not yet
+      been constructed:
+        - SHOULD re-send `channel_ready` with the nonce fields set.
+- Once a `channel_ready` message with announcement nonces has been both sent and
+  received:
+    - MUST proceed with constructing and sending the `announcement_signatures_2`
+      message.
 
-The final signature included in the `channel_announcement_v2` message will be a
-single [BIP-340][bip-340] signature that needs to be valid for a public key
-derived by aggregating all the `node_ID` and `bitcoin_key` public keys. The
-signature for this key will thus be created by aggregating (via MuSig2) four
-partial signatures. One for each of the keys: `node_ID_1`, `node_ID_2`, 
-`bitcoin_key_1` and `bitcoin_key_2`. A nonce will need to be generated and
-exchanged for each of the keys and so each node will need to send the other node
-two nonces. The `announcement_node_nonce` is for `node_ID_x` and the 
-`announcement_bitcoin_nonce` is for `bitcoin_key_x`.
+- TODO: recommend nonce generation technique.
+- TODO: can we guarantee progress here?
 
-Since the channel can only be announced once the `channel_ready` messages have 
-been exchanged and since it is generally preferred to keep nonce exchanges as 
-Just In Time as possible, the nonces are exchanged via the `channel_ready` 
-message.
+The recipient:
 
-## The `announcement_signatures_2` Message
+- If the nonce fields are set:
+    - If only one of the nonce fields are set:
+        - MUST ignore the message.
+        - SHOULD send a warning.
+        - MAY fail the connection.
+    - If the channel has not reached sufficient confirmations:
+        - SHOULD ignore the message.
+    - Otherwise:
+        - MUST store the nonces so that they can be used for the partial signature
+          construction required for constructing the `announcement_signatures`
+          message.
+        - If it has not yet done so, SHOULD respond with its own `channel_ready`
+          message with the nonce fields set.
+
+#### Rationale
+
+It cannot be a requirement that a node include the nonce fields in the
+`channel_ready` since for cases such as zero-conf channels, nodes may send
+`channel_ready` multiple times throughout the life of the channel to update it's
+preferred channel alias, and it does not make sense to require that the nonce
+fields be populated once the channel has already been announced.
+
+### The `announcement_signatures_2` Message
 
 Like the legacy `announcement_signatures` message, this is a direct message
 between the two endpoints of a channel and serves as an opt-in mechanism to
-allow the announcement of the channel to the rest of the network. 
+allow the announcement of the channel to the rest of the network.
 
-1. type: xxx (`announcement_signatures_2`)
-2. data (tlv_stream):
-   1. type: 0 (`channel_id`)
-   2. data:
-       * [`channel_id`:`channel_id`]
-   3. type: 2 (`short_channel_id`)
-   4. data:
-       * [`short_channel_id`:`short_channel_id`]
-   5. type: 4 (`partial_signature`)
-   6. data:
-       * [`partial_signature`:`partial_signature`]
+1. type: 260 (`announcement_signatures_2`)
+2. data:
+    * [`channel_id`:`channel_id`]
+    * [`short_channel_id`:`short_channel_id`]
+    * [`partial_signature`:`partial_signature`]
 
-### Requirements
+#### Requirements
 
-The requirements are similar to the ones defined for the legacy 
-`announcement_signatures`. The below requirements assume that the 
+The requirements are similar to the ones defined for the legacy
+`announcement_signatures`. The below requirements assume that the
 `option_taproot` channel type was set in `open_channel`.
 
 A node:
-- if the `open_channel` message has the `announce_channel` bit set AND a 
+- if the `open_channel` message has the `announce_channel` bit set AND a
   `shutdown` message has not been sent:
-  - MUST send the `announcement_signatures_2` message once `channel_ready`
-      has been sent and received AND the funding transaction has at least six 
-      confirmations.
-  - MUST set the `partial_signature` field to the 32-byte `partial_sig` value of
-    the partial signature calculated as described in [Partial Signature 
-    Calculation](#partial-signature-calculation). The message to be signed is
-    `MsgHash("channel_announcement", "announcement_sig", m)` where `m` is the
-    serialisation of the `channel_announcement_2` message excluding the
-    `announcement_sig` field (see the
-    [`MsgHash`](#signature-message-construction) definition).
+    - MUST send the `announcement_signatures_2` message once a `channel_ready`
+      message containing the announcement nonces has been sent and received AND
+      the funding transaction has at least six confirmations.
+    - MUST set the `partial_signature` field to the 32-byte `partial_sig` value
+      of the partial signature calculated as described in [Partial Signature
+      Calculation](#partial-signature-calculation). The message to be signed is
+      `MsgHash("channel_announcement", "announcement_sig", m)` where `m` is the
+      serialisation of the `channel_announcement_2` message tlv stream (see the
+      [`MsgHash`](#signature-message-construction) definition).
 - otherwise:
     - MUST NOT send the `announcement_signatures_2` message.
 - upon reconnection (once the above timing requirements have been met):
-    - MUST respond to the first `announcement_signatures_2` message with its own
-      `announcement_signatures_2` message.
+    - MUST re-send a `channel_ready` message with the nonce fields set and await
+      a reply.
+    - Then, MUST respond to the first `announcement_signatures_2` message with
+      its own `announcement_signatures_2` message.
     - if it has NOT received an `announcement_signatures_2` message:
-        - SHOULD retransmit the `announcement_signatures_2` message.
+        - SHOULD retransmit the `channel_ready` and `announcement_signatures_2`
+          messages.
 
 A recipient node:
 - if the `short_channel_id` is NOT correct:
@@ -408,239 +418,182 @@ A recipient node:
     - MAY send a `warning` and close the connection, or send an `error` and fail
       the channel.
 
-### Rationale
+#### Rationale
 
 The message contains the necessary partial signature, by the sender, that the
 recipient will be able to combine with their own partial signature to construct
-the signature to put in the `channel_announcement_v2` message. Unlike the legacy
-`announcement_signatures` message, `announcement_signatures_v2` only has one
+the signature to put in the `channel_announcement_2` message. Unlike the legacy
+`announcement_signatures` message, `announcement_signatures_2` only has one
 signature field. This field is a MuSig2 partial signature which is the
 aggregation of the two signatures that the sender would have created (one for
 `bitcoin_key_x` and another for `node_ID_x`).
 
-## The `channel_announcement_2` Message
+### The `channel_announcement_2` Message
 
-This gossip message contains ownership information regarding a taproot channel. 
-It ties each on-chain Bitcoin key that makes up the taproot output key to the 
-associated Lightning node key, and vice-versa. The channel is not practically 
-usable until at least one side has announced its fee levels and expiry, using 
+This gossip message contains ownership information regarding a taproot channel.
+It ties each on-chain Bitcoin key that makes up the taproot output key to the
+associated Lightning node key, and vice-versa. The channel is not practically
+usable until at least one side has announced its fee levels and expiry, using
 `channel_update_2`.
 
 See [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification)
 for more information regarding the requirements for proving the existence of a
 channel.
 
-1. type: xxx (`channel_announcement_2`)
-2. data: (tlv_stream):
-   1. type: 0 (`announcement_sig`)
-   2. data:
-        * [`bip340_sig`:`bip340_sig`]
-   3. type: 1 (`chain_hash`)
-   4. data:
-       * [`chain_hash`:`chain_hash`]
-   5. type: 2 (`features`)
-   6. data:
-        * [`...*byte`: `features`]
-   7. type: 4 (`short_channel_id`)
-   8. data:
+1. type: 267 (`channel_announcement_2`)
+2. data:
+    * [`bip340_sig`:`announcement_signature`]
+    * [`channel_announcement_2_tlvs`:`tlvs`]
+
+1. `tlv_stream`: `channel_announcement_2_tlvs`
+2. types:
+    1. type: 0 (`chain_hash`)
+    2. data:
+        * [`chain_hash`:`chain_hash`]
+    1. type: 2 (`features`)
+    2. data:
+        * [`...*byte`:`features`]
+    1. type: 4 (`short_channel_id`)
+    2. data:
         * [`short_channel_id`:`short_channel_id`]
-   9. type: 6 (`node_id_1`)
-   10. data:
-        * [`point`:`point`]
-   11. type: 8 (`node_id_2`)
-   12. data:
-       * [`point`:`point`]
-   13. type: 3 (`bitcoin_key_1`)
-   14. data:
-       * [`point`:`point`]
-   15. type: 5 (`bitcoin_key_2`)
-   16. data:
-       * [`point`:`point`]
-   17. type: 7 (`tap_tweak`)
-   18. data:
-       * [`point`:`point`]
+    1. type: 6 (`capacity_satoshis`)
+    2. data:
+        * [`u64`:`capacity_satoshis`]
+    1. type: 8 (`node_id_1`)
+    2. data:
+        * [`point`:`node_id_1`]
+    1. type: 10 (`node_id_2`)
+    2. data:
+        * [`point`:`node_id_2`]
+    1. type: 12 (`bitcoin_key_1`)
+    2. data:
+        * [`point`:`bitcoin_key_1`]
+    1. type: 14 (`bitcoin_key_2`)
+    2. data:
+        * [`point`:`bitcoin_key_2`]
+    1. type: 16 (`merkle_root_hash`)
+    2. data:
+        * [`32*byte`:`hash`]
 
-### Requirements
+#### Message Field Descriptions
 
-The origin node:
+TODO
 
-- If the chain being referred to is not the Bitcoin blockchain:
-  - MUST set `chain_hash` to the 32-byte hash that uniquely identifies the chain
-    that the channel was opened within:
-- otherwise, MUST not set `chain_has` as the _Bitcoin blockchain_ is assumed. 
-- MUST set `short_channel_id` to refer to the confirmed funding transaction, as
-  specified in [BOLT #2](02-peer-protocol.md#the-channel_ready-message).
-    - Note: the corresponding output MUST be a P2TR, as described
-      in [Taproot Channel Proof and Verification](#taproot-channel-proof-and-verification).
-- MUST set `node_id_1` and `node_id_2` to the public keys of the two nodes
-  operating the channel, such that `node_id_1` is the lexicographically-lesser
-  of the two compressed keys sorted in ascending lexicographic order.
-- MUST set `bitcoin_key_1` and `bitcoin_key_2` to `node_id_1` and `node_id_2`'s
-  respective `funding_pubkey`s.
-- MUST set `features` based on what features were negotiated for this channel,
-  according to [BOLT #9](09-features.md#assigned-features-flags)
-- MUST set `announcement_sig` signature to the [BIP-340][bip-340] signature
-  calculated by passing the partial signatures sent and received during the
-  `announcement_signatures_2` exchange to the
-  [MuSig2 PartialSigAgg][musig-partial-sig-agg] function.
+#### Requirements
 
-The receiving node:
+TODO
 
-- If any even typed messages are not present:
-    - SHOULD send a `warning`.
-    - MAY close the connection.
-    - MUST ignore the message.
-- MUST verify the integrity AND authenticity of the message by verifying the
-  `announcement_sig` as per [BIP 340][bip-340-verify].
-- if there is an unknown even bit in the `features` field:
-    - MUST NOT attempt to route messages through the channel.
-- if the `short_channel_id`'s output does NOT correspond to a P2TR (using
-  `bitcoin_key_1` and `bitcoin_key_2`, as specified in
-  [BOLT #3](03-transactions.md#funding-transaction-output)) OR the output is
-  spent:
-    - MUST ignore the message.
-- if the specified `chain_hash` is unknown to the receiver:
-    - MUST ignore the message.
-- otherwise:
-    - if `announcement_sig` is invalid OR NOT correct:
-        - SHOULD send a `warning`.
-        - MAY close the connection.
-        - MUST ignore the message.
-    - otherwise:
-        - if `node_id_1` OR `node_id_2` are blacklisted:
-            - SHOULD ignore the message.
-        - otherwise:
-            - if the transaction referred to was NOT previously announced as a
-              channel:
-                - SHOULD queue the message for rebroadcasting.
-                - MAY choose NOT to for messages longer than the minimum
-                  expected length.
-        - if it has previously received a valid `channel_announcement_2`, for
-          the same transaction, in the same block, but for a
-          different `node_id_1` or `node_id_2`:
-            - SHOULD blacklist the previous message's `node_id_1`
-              and `node_id_2`, as well as this `node_id_1` and `node_id_2` AND
-              forget any channels connected to them.
-        - otherwise:
-            - SHOULD store this `channel_announcement_2`.
-- once its funding output has been spent OR reorganized out:
-    - SHOULD forget a channel after a 12-block delay.
+### The `node_announcement_2` Message
 
-### Rationale
-
-Both nodes are required to sign to indicate they are willing to route other
-payments via this channel (i.e. be part of the public network); requiring their
-aggregated MuSig2 Schnorr signature proves that they control the channel.
-
-The blacklisting of conflicting nodes disallows multiple different
-announcements. Such conflicting announcements should never be broadcast by any
-node, as this implies that keys have leaked.
-
-While channels should not be advertised before they are sufficiently deep, the
-requirement against rebroadcasting only applies if the transaction has not moved
-to a different block.
-
-In order to avoid storing excessively large messages, yet still allow for
-reasonable future expansion, nodes are permitted to restrict rebroadcasting
-(perhaps statistically).
-
-New channel features are possible in the future: backwards compatible (or
-optional) features will have _odd_ feature bits, while incompatible features
-will have _even_ feature bits
-(["It's OK to be odd!"](00-introduction.md#glossary-and-terminology-guide)).
-
-A delay of 12-blocks is used when forgetting a channel on funding output spend
-as to permit a new `channel_announcement_2` to propagate which indicates this
-channel was spliced.
-
-## The `node_announcement_2` Message
-
-This gossip message, like the legacy `node_announcement` message, allows a node 
-to indicate extra data associated with it, in addition to its public key. 
+This gossip message, like the legacy `node_announcement` message, allows a node
+to indicate extra data associated with it, in addition to its public key.
 To avoid trivial denial of service attacks, nodes not associated with an already
 known channel (legacy or taproot) are ignored.
 
-Unlike the legacy `node_announcement` message, this message makes use of a 
-Schnorr signature instead of an ECDSA one. This will allow nodes to be backed 
+Unlike the legacy `node_announcement` message, this message makes use of a
+BIP340 signature instead of an ECDSA one. This will allow nodes to be backed
 by multiple keys since MuSig2 can be used to construct the single signature.
 
-The other two main differences from the legacy message are that the timestamp 
-is now a block height and that the message is purely TLV based.
+1. type 269
+2. data:
+    * [`bip340_sig`:`announcement_sig`]
+    * [`node_announcement_2_tlvs`:`tlvs`]
 
-1. type: xxx (`node_announcement_2`)
-2. data: (tlv_stream):
-    1. type: 0 (`announcement_sig`)
+1. `tlv_stream`: `node_announcement_2_tlvs`
+2. types:
+    1. type: 0 (`features`)
+    1. type: 1 (`color`)
     2. data:
-        * [`bip340_sig`:`bip340_sig`]
-    3. type: 2 (`features`)
-    4. data:
+        * [`rgb_color`:`rgb_color`]
+    2. data:
         * [`...*byte`: `features`]
-    5. type: 4 (`block_height`)
-    6. data:
+    1. type: 2 (`block_height`)
+    1. type: 3 (`alias`)
+    2. data:
+        * [`...*utf8`:`alias`]
+    2. data:
         * [`u32`: `block_height`]
-    7. type: 6 (`node_ID`)
-    8. data: 
+    1. type: 4 (`node_id`)
+    2. data:
         * [`point`:`node_id`]
-    9. type: 1 (`color`)
-    10. data:
-         * [`rgb_color`:`rgb_color`]
-    11. type: 3 (`alias`)
-    12. data:
-         * [`...*utf8`:`alias`]
-    13. type: 5 (`ipv4_addrs`)
-    14. data: 
-         * [`...*ipv4_addr`: `ipv4_addresses`]  
-    15. type: 7 (`ipv6_addrs`)
-    16. data:
-         * [`...*ipv6_addr`: `ipv6_addresses`]
-    17. type: 9 (`tor_v3_addrs`)
-    18. data: 
-         * [`...*tor_v3_addr`: `tor_v3_addresses`]
-    19. type: 11 (`dns_hostname`)
-    20. data:
-         * [`dns_hostname`: `dns_hostname`]
+    1. type: 5 (`ipv4_addrs`)
+    2. data:
+        * [`...*ipv4_addr`: `ipv4_addresses`]
+    1. type: 7 (`ipv6_addrs`)
+    2. data:
+        * [`...*ipv6_addr`: `ipv6_addresses`]
+    1. type: 9 (`tor_v3_addrs`)
+    2. data:
+        * [`...*tor_v3_addr`: `tor_v3_addresses`]
+    1. type: 11 (`dns_hostnames`)
+    2. data:
+        * [`...*dns_hostname`: `dns_hostnames`]
 
 The following subtypes are defined:
 
 1. subtype: `rgb_color`
 2. data:
-   * [`byte`:`red`]
-   * [`byte`:`green`]
-   * [`byte`:`blue`]
+    * [`byte`:`red`]
+    * [`byte`:`green`]
+    * [`byte`:`blue`]
 
-3. subtype: `ipv4_addr`
-4. data:
+1. subtype: `ipv4_addr`
+2. data:
     * [`u32`:`addr`]
-    * [`tu16`:`port`]
+    * [`u16`:`port`]
 
-5. subtype: `ipv6_addr`
-6. data:
+1. subtype: `ipv6_addr`
+2. data:
     * [`16*byte`:`addr`]
-    * [`tu16`:`port`]
- 
-7. subtype: `tor_v3_addr`
-8. data:
+    * [`u16`:`port`]
+
+1. subtype: `tor_v3_addr`
+2. data:
     * [`35*utf8`:`onion_addr`]
-    * [`tu16`:`port`]
+    * [`u16`:`port`]
 
-9. subtype: `dns_hostname`
-10. data:
-     * [`...*utf8`:`hostname`]
-     * [`tu16`:`port`]
+1. subtype: `dns_hostname`
+2. data:
+    * [`u16`:`len`]
+    * [`len*utf8`:`hostname`]
+    * [`u16`:`port`]
 
-`tor_v3_address` is a Tor version 3 ([prop224]) onion service address;
-Its `onion_addr` encodes:
-`[32:32_byte_ed25519_pubkey] || [2:checksum] || [1:version]`, where
-`checksum = sha3(".onion checksum" | pubkey || version)[:2]`.
+#### Message Field Descriptions
 
-The `dns_hostname` `hostname` MUST be ASCII characters. Non-ASCII characters
-MUST be encoded using [Punycode][punycode]. The length of the `hostname` cannot
-exceed 255 bytes.
+- `bip340_sig` is the [BIP340][bip-340] signature for the `node_id` key. The
+  message to be signed is `MsgHash("node_announcement_2", "bip340_sig", m)`
+  where `m` is the serialised TLV stream (see the
+  [`MsgHash`](#signature-message-construction) definition).
+- `features` is a bit vector with bits set according to [BOLT #9](09-features.md#assigned-features-flags)
+- `block_height` allows for ordering or messages in the case of multiple
+  announcements and also allows for natural rate limiting of
+  `node_announcement_2` messages.
+- `node_id` is the public key associated with this node. It must match a node ID
+  that has previously been announced in the `node_id_1` or `node_id_2` fields of
+  a `channel_announcement` or `channel_announcement_2` message for a channel
+  that is still open.
+- `rgb_color` is an optional field that a node may use to assign itself a color.
+- `alias` is an optional field that a node may use to assign itself an alias
+  that can then be used for a nicer UX on intelligence services. If this field
+  is set, then it MUST be 32 utf8 characters or less.
+- `ipv4_addr` is an ipv4 address and port.
+- `ipv6_addr` is an ipv6 address and port.
+- `tor_v3_addr` is a Tor version 3 ([prop224]) onion service address;
+  Its `onion_addr` encodes:
+  `[32:32_byte_ed25519_pubkey] || [2:checksum] || [1:version]`, where
+  `checksum = sha3(".onion checksum" | pubkey || version)[:2]`.
+- `dns_hostname` is a DNS hostname. The `hostname` MUST be ASCII characters.
+  Non-ASCII characters MUST be encoded using [Punycode][punycode]. The length of
+  the `hostname` cannot exceed 255 bytes.
 
-### Requirements
+#### Requirements
+
+TODO: flesh out when it is ok to send new vs old node announcement. Is it ever
+ok to send both? if so - what if the info inside them differs?
 
 The sender:
 
+- MUST set TLV fields 0, 2 and 4.
 - MUST set `announcement_sig` to a valid [BIP340][bip-340] signature for the
   `node_id` key. The message to be signed is
   `MsgHash("node_announcement_2", "announcement_sig", m)` where `m` is the
@@ -649,11 +602,13 @@ The sender:
   [`MsgHash`](#signature-message-construction) definition).
 - MAY set `color` and `alias` to customise appearance in maps and graphs.
 - If the node sets the `alias`:
-  - MUST use 32 utf8 characters or less. 
+    - MUST use 32 utf8 characters or less.
 - MUST set `block_height` to be greater than that of any previous
   `node_announcement_2` it has previously created.
-    - MUST set it to a block height less than the latest block's height but no
-      more than 1440 lower.
+- TODO: how to determine a lower bound for the block_height of the node_ann?
+  cant say "must be greater than or = oldest advertised channel" since a node
+  could open a new channel and close the previous which would then invalidate
+  the node_announcement.
 - If the node wishes to announce its willingness to accept incoming network
   connections:
     - SHOULD set at least one of types 7-10.
@@ -665,12 +620,10 @@ The sender:
 - MUST not create a `ipv4_addr`, `ipv6_addr` or `dns_hostname` with a `port`
   equal to 0.
 - MUST set `features` according to [BOLT #9][bolt-9-features].
-- SHOULD only start using this message once they no longer have announced legacy
-  channels.
-    
-The receiving node:
 
-- If any type between even-typed values are missing:
+The receiver:
+
+- If type 0, 2 or 4 is missing:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
@@ -682,7 +635,7 @@ The receiving node:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST NOT process the message further.
-- if `announcement_sig` is NOT a valid [BIP340][bip-340] signature (using 
+- if `announcement_sig` is NOT a valid [BIP340][bip-340] signature (using
   `node_id` over the message):
     - SHOULD send a `warning`.
     - MAY close the connection.
@@ -694,17 +647,16 @@ The receiving node:
     - MUST NOT route a payment _through_ the node.
 - if `port` is equal to 0 for any `ipv6_addr` OR `ipv4_addr` OR `hostname`:
     - SHOULD ignore that address.
-- if `node_id` is NOT previously known from a `channel_announcement` OR 
-  `channel_announcement_2` message, OR if `blockheight` is NOT greater than the 
+- if `node_id` is NOT previously known from a `channel_announcement` OR
+  `channel_announcement_2` message, OR if `blockheight` is NOT greater than the
   last-received `node_announcement_2` from this `node_id`:
-      - SHOULD ignore the message.
+    - SHOULD ignore the message.
 - otherwise:
-    - if `block_height` is greater than the last-received `node_announcement_2` 
+    - if `block_height` is greater than the last-received `node_announcement_2`
       from this `node_id`:
-          - SHOULD queue the message for rebroadcasting.
+        - SHOULD queue the message for rebroadcasting.
 - MAY use `rgb_color` AND `alias` to reference nodes in interfaces.
     - SHOULD insinuate their self-signed origins.
-- SHOULD ignore any legacy `node_announcement` message for this `node_ID`.
 
 ### Rationale
 
@@ -713,24 +665,21 @@ optional) ones will have _odd_ `feature` _bits_, incompatible ones will have
 _even_ `feature` _bits_. These will be propagated normally; incompatible feature
 bits here refer to the nodes, not the `node_announcement_2` message itself.
 
-Since the legacy `node_announcement` uses a UNIX based `timestamp` field and 
-this message uses block heights, deciding which message is the latest one could
-be tricky. To simplify the logic, the decision is made that once a 
-`node_announcement_2` is received, then any legacy `node_announcement` messages 
-received for the same `node_id` can be ignored.
-
 ### Security Considerations for Node Aliases
 
-The security considerations for node aliases mentioned in 
+The security considerations for node aliases mentioned in
 [BOLT #7][bolt-7-alias-security] apply here too.
 
-## The `channel_update_2` Message
+### The `channel_update_2` Message
 
-After a channel has been initially announced via `channel_announcement_2`, each 
-side independently announces the fees and minimum expiry delta it requires to 
-relay HTLCs through this channel. Each uses the 8-byte short channel id that 
-matches the `channel_announcement_2` and the 1-bit `channel_flags` field to 
-indicate which end of the channel it's on (origin or final). A node can do this 
+- TODO: should updates for legacy channels also sometimes be broadcast using the
+  new format for easier set reconciliation?
+
+After a channel has been initially announced via `channel_announcement_2`, each
+side independently announces the fees and minimum expiry delta it requires to
+relay HTLCs through this channel. Each uses the 8-byte short channel id that
+matches the `channel_announcement_2` and the `direction` field to
+indicate which end of the channel it's on (origin or final). A node can do this
 multiple times, in order to change fees.
 
 Note that the `channel_update` gossip message is only useful in the context
@@ -741,165 +690,170 @@ come into play. When building the route, amounts and expiries for HTLCs need
 to be calculated backward from the destination to the source. The exact initial
 value for `amount_msat` and the minimal value for `cltv_expiry`, to be used for
 the last HTLC in the route, are provided in the payment request
+
 (see [BOLT #11][[bolt-11-tagged-fields]]).
+1. type 271
+2. data:
+    * [`bip340_sig`:`bip340_sig`]
+    * [`channel_update_2_tlvs`:`tlvs`]
 
-1. type: xxx (`channel_update_2`)
-2. data: (tlv_stream):
-    1. type: 0 (`update_sig`)
+1. `tlv_stream`: `channel_update_2_tlvs`
+2. types:
+    1. type: 0 (`chain_hash`)
     2. data:
-        * [`bip340_sig`:`bip340_sig`]
-    3. type: 1 (`chain_hash`)
-    4. data:
         * [`chain_hash`:`chain_hash`]
-    5. type: 2 (`block_height`)
-    6. data:
-        * [`u32`: `block_height`]
-    7. type: 4 (`channel_flags`)
-    8. data:
-       * [`...*byte`, `channel_flags`]
-    9. type: 6 (`cltv_expiry_delta`)
-    10. data:
-        * [`tu32`, `cltv_expiry_delta`]
-    11. type: 8 (`htlc_min_msat`)
-    12. data: 
-        * [`tu64`, `htlc_min_msat`]
-    13. type: 10 (`htlc_max_msat`)
-    14. data:
-       * [`tu64`, `htlc_max_msat`]
-    15. type: 12 (`fee_base_msat`)
-    16. data:
-       * [`tu32`, `fee_base_msat`]
-    17. type: 14 (`fee_prop_millionths`)
-    18. data:
-      * [`tu32`, `fee_prop_millionths`]
+    1. type: 2 (`short_channel_id`)
+    2. data:
+        * [`short_channel_id`:`short_channel_id`]
+    1. type: 4 (`block_height`)
+    2. data:
+        * [`u32`:`block_height`]
+    1. type: 6 (`disable_flags`)
+    2. data:
+        * [`byte`:`disable_flags`]
+    1. type: 8 (`direction`)
+    2. data:
+        * [`boolean_tlv`:`direction`]
+    1. type: 10 (`cltv_expiry_delta`)
+    2. data:
+        * [`u16`:`cltv_expiry_delta`]
+    1. type: 12 (`htlc_minimum_msat`)
+    2. data:
+        * [`u64`:`htlc_minimum_msat`]
+    1. type: 14 (`htlc_maximum_msat`)
+    2. data:
+        * [`u64`:`htlc_maximum_msat`]
+    1. type: 16 (`fee_base_msat`)
+    2. data:
+        * [`u32`:`fee_base_msat`]
+    1. type: 18 (`fee_proportional_millionths`)
+    2. data:
+        * [`u32`:`fee_proportional_millionths`]
 
-The `channel_flags` bitfield is used to indicate the direction of the channel:
-it identifies the node that this update originated from and signals various
-options concerning the channel. The following table specifies the meaning of its
-individual bits:
 
-| Bit Position | Name        | Meaning                          |
-|--------------|-------------|----------------------------------|
-| 0            | `direction` | Direction this update refers to. |
-| 1            | `disable`   | Disable the channel.             |
+The `disable_flags` bitfield is used to indicate that the channel is temporarily
+disabled. The following table specifies the meaning of the individual bits:
 
-The `node_id` for the signature verification is taken from the corresponding
-`channel_announcement_2`: `node_id_1` if the least-significant bit of flags is
-0 or `node_id_2` otherwise.
+| Bit Position  | Name       | Meaning                                         |
+|---------------|------------|-------------------------------------------------|
+| 0             | `incoming` | The node can't receive via this channel         |
+| 1             | `outgoing` | The node can't forward or send via this channel |
 
-### Requirements
+Both the `incoming` and `outgoing` bit can be set to indicate that the channel
+peer is offline.
+
+#### Message Field Descriptions
+
+- The `chain_hash` is used to identify the blockchain containing the channel
+  being referred to.
+- `short_channel_id` is the unique identifier of the channel. If the channel is
+  unannounced, then this may be set to an agreed upon alias.
+- `block_height` is the timestamp associated with the message. A node may not
+  send two `channel_update` messages with the same `block_height`. The
+  `block_height` must also be greater than or equal to the block height
+  indicated by the `short_channel_id` used in the `channel_announcement` and
+  must not be less than current best block height minus 2016 (~2 weeks of
+  blocks).
+- The `disable` bit field can be used to advertise to the network that a channel
+  is disabled and that it should not be used for routing. The individual
+  `disable_flags` bits can be used to communicate more fine-grained information.
+- The `direction` is used to indicate which node in the channel node pair
+  has created and signed this message. If the node was `node_id_1` in the
+  `channel_announcment` message then the `direction` is 0 (false) otherwise
+  it is 1 (true) and the node is `node_id_2` in the `channel_announcement`
+  message.
+- `cltv_expiry_delta` is the number of blocks that the node will subtract from
+  an incoming HTLC's `cltv_expiry`.
+- `htlc_minimum_msat` is the minimum HTLC value (in millisatoshi) that the
+  channel peer will accept.
+- `htlc_maximum_msat` is the maximum value the node will send through this
+  channel for a single HTLC.
+    - MUST be less than or equal to the channel capacity
+    - MUST be less than or equal to the `max_htlc_value_in_flight_msat` it
+      received from the peer in the `open_channel` message.
+- `fee_base_msat` is the base fee (in millisatoshis) that the node will charge
+  for an HTLC.
+- `fee_proportional_millionths` is the amount (in millionths of a satoshi) that
+  node will charge per transferred satoshi.
+
+#### TLV Defaults
+
+For types 0, 6, 8, 10, 12, 14, 16 and 18, the following defaults apply if the
+TLV is not present in the message:
+
+| `channel_update_2` TLV Type        | Default Value                                                      | Comment                                                                                     |
+|------------------------------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| 0  (`chain_hash`)                  | `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000` | The hash of the genesis block of the mainnet Bitcoin blockchain.                            | 
+| 6  (`disable`)                     | empty                                                              |                                                                                             | 
+| 8  (`direction`)                   | false                                                              |                                                                                             | 
+| 10 (`cltv_expiry_delta`)           | 80                                                                 |                                                                                             | 
+| 12 (`htlc_minimum_msat`)           | 1                                                                  |                                                                                             | 
+| 14 (`htlc_maximum_msat`)           | floor(channel capacity / 2)                                        | // TODO: remove this since makes encoding/decoding dependent on things outside the message? | 
+| 16 (`fee_base_msat`)               | 1000                                                               |                                                                                             | 
+| 18 (`fee_proportional_millionths`) | 1                                                                  |                                                                                             |
+
+#### Requirements
 
 The origin node:
-- If the chain being referred to is not the Bitcoin blockchain:
-    - MUST set `chain_hash` to the 32-byte hash that uniquely identifies the 
-      chain that the channel was opened within:
-- otherwise, MUST not set `chain_hash` as the _Bitcoin blockchain_ is assumed.
-- MUST NOT send `channel_update_2` before `channel_ready` has been received. 
-- MUST NOT send `channel_update_2` for legacy (non-taproot) channels.
-- MAY create a `channel_update_2` to communicate the channel parameters to the
-  channel peer, even though the channel has not yet been announced (i.e. the
-  `announce_channel` bit was not set).
+
+- For all fields with defined defaults:
+    - SHOULD not include the field in the TLV stream if the default value is
+      desired.
+- MUST use the `channel_update_2` message to communicate channel parameters of a
+  Taproot channel.
+- MAY use the `channel_update_2` message to communicate channel parameters of a
+  legacy (P2SH) channel.
+- MUST NOT send a created `channel_update_2` before `channel_ready` has been
+  received.
+- For an unannounced channel (i.e. one where the `announce_channel` bit was not
+  set in `open_channel`):
+    - MAY create a `channel_update_2` to communicate the channel parameters to the
+      channel peer.
     - MUST set the `short_channel_id` to either an `alias` it has received from
       the peer, or the real channel `short_channel_id`.
-    - MUST NOT forward such a `channel_update` to other peers, for privacy
+    - MUST NOT forward such a `channel_update_2` to other peers, for privacy
       reasons.
-    - Note: such a `channel_update`, one not preceded by a
-      `channel_announcement`, is invalid to any other peer and would be
-      discarded.
-- MUST set `update_sig` to a valid [BIP340][bip-340] signature for its own
+- For announced channels:
+    - MUST set `chain_hash` AND `short_channel_id` to match the 32-byte hash AND
+      8-byte channel ID that uniquely identifies the channel specified in the
+      `channel_announcement_2` message.
+- MUST set `bip340_sig` to a valid [BIP340][bip-340] signature for its own
   `node_id` key. The message to be signed is
-  `MsgHash("channel_update_2", "update_sig", m)` where `m` is the serialisation
-  of the `channel_update` message excluding the `update_sig` field (see the
+  `MsgHash("channel_update_2", "bip340_sig", m)` where `m` is the serialised
+  TLV stream of the `channel_update` (see the
   [`MsgHash`](#signature-message-construction) definition).
-- MUST set `chain_hash` AND `short_channel_id` to match the 32-byte hash AND
-  8-byte channel ID that uniquely identifies the channel specified in the
-  `channel_announcement_2` message.
-- if the origin node is `node_id_1` in the message:
-    - MUST set the `direction` bit of `channel_flags` to 0.
-- otherwise:
-    - MUST set the `direction` bit of `channel_flags` to 1.
-- MUST set `htlc_maximum_msat` to the maximum value it will send through this
-  channel for a single HTLC.
-    - MUST set this to less than or equal to the channel capacity.
-    - MUST set this to less than or equal to `max_htlc_value_in_flight_msat` it
-      received from the peer.
-- MAY create and send a `channel_update_2` with the `disable` bit set to 1, to
-  signal a channel's temporary unavailability (e.g. due to a loss of
-  connectivity) OR permanent unavailability (e.g. prior to an on-chain
-  settlement).
-    - MAY send a subsequent `channel_update_2` with the `disable` bit set to 0
-      to re-enable the channel.
-- MUST set `block_height` greater or equal to the block height that the 
-  channel's funding transaction was mined in AND to greater than any 
-  previously-sent `channel_update_2` for this `short_channel_id` AND no less 
-  than 1440 blocks below the current best block height . 
-- MUST set `cltv_expiry_delta` to the number of blocks it will subtract from
-  an incoming HTLC's `cltv_expiry`.
-- MUST set `htlc_minimum_msat` to the minimum HTLC value (in millisatoshi)
-  that the channel peer will accept.
-- MUST set `fee_base_msat` to the base fee (in millisatoshi) it will charge
-  for any HTLC.
-- MUST set `fee_proportional_millionths` to the amount (in millionths of a
-  satoshi) it will charge per transferred satoshi.
-- SHOULD NOT create redundant `channel_update_2`s
+- SHOULD NOT create redundant `channel_update_2`s.
 - If it creates a new `channel_update_2` with updated channel parameters:
-    - SHOULD keep accepting the previous channel parameters for 10 minutes
+    - SHOULD keep accepting the previous channel parameters for 2 blocks.
 
 The receiving node:
 
-- if the `short_channel_id` does NOT match a previous `channel_announcement_2`,
-  OR if the channel has been closed in the meantime:
+- If the `short_channel_id` does NOT match a previous `channel_announcement_2`
+  or `channel_announcement`, OR if the channel has been closed in the meantime:
     - MUST ignore `channel_update_2`s that do NOT correspond to one of its own
       channels.
-- SHOULD accept `channel_update_2`s for its own taproot channels (even if
-  non-public), in order to learn the associated origin nodes' forwarding
-  parameters.
-- if `update_sig` is NOT a valid [BIP340][bip-340] signature (using `node_id`
+- SHOULD accept `channel_update_2`s for its own channels (even if non-public),
+  in order to learn the associated origin nodes' forwarding parameters.
+- if `bip340_sig` is NOT a valid [BIP340][bip-340] signature (using `node_id`
   over the message):
     - SHOULD send a `warning` and close the connection.
     - MUST NOT process the message further.
-- if the specified `chain_hash` value is unknown (meaning it isn't active on
-  the specified chain):
-    - MUST ignore the channel update.
-- if the `block_height` is equal to the last-received `channel_update_2` for 
-  this `short_channel_id` AND `node_id`:
-    - if the fields below `block_height` differ:
-        - MAY blacklist this `node_id`.
-        - MAY forget all channels associated with it.
-    - if the fields below `block_height` are equal:
-        - SHOULD ignore this message
-- if `block_height` is lower than that of the last-received
-  `channel_update_2` for this `short_channel_id` AND for `node_id`:
-    - SHOULD ignore the message.
-- otherwise:
-    - if the `block_height` is a block height greater than the current best block
-      height:
-      - MAY discard the `channel_update_2`.
-    - if the `block_height` block height is more than 1440 blocks less than the 
-      current best block height:
-        - MAY discard the `channel_update_2`.
-    - otherwise:
-        - SHOULD queue the message for rebroadcasting.
-- if `htlc_maximum_msat` is greater than channel capacity:
-    - MAY blacklist this `node_id`
-    - SHOULD ignore this channel during route considerations.
-- otherwise:
-    - SHOULD consider the `htlc_maximum_msat` when routing.
-  
-### Rationale
+
+#### Rationale
+
+- An even type is used so that best-effort propagation can be used.
+
+### Query Messages
 
 TODO
 
-## Query Messages
-
-TODO: any updates that need to happen to this section? 
-
 # Appendix A: Algorithms
 
-### Partial Signature Calculation
+## Partial Signature Calculation
 
-When both nodes have exchanged `channel_ready` then they will each have the
-following information:
+When both nodes have exchanged a `channel_ready` message containing the
+`announcement_node_pubnonce` and `announcement_bitcoin` fields then they will
+each have the following information:
 
 - `node_1` will know:
     - `bitcoin_priv_key_1`, `node_ID_priv_key_1`,
@@ -990,7 +944,7 @@ signature aggregation is simply the addition of the two signatures:
 
 Where `n` is the [secp256k1][secp256k1] curve order.
 
-### Partial Signature Verification
+## Partial Signature Verification
 
 Since the partial signature put in `announcement_signatures_2` is the addition
 of two of four signatures required to make up the final MuSig2 signature, the
@@ -1031,25 +985,115 @@ found in the [MuSig2][musig-session-ctx] spec.
 - Let `g = 1` if `has_even_y(Q)`, otherwise `let g = -1 mod n`
 - Fail if `s*G != R_e + e*g*P`
 
-### Signature Message Construction
+## Verifying the `channel_announcement_2` signature
+
+For all the following cases, it should be verified that the output at the
+provided `short_channel_id` is an unspent Taproot output.
+
+### The 3-of-3 MuSig2 Scenario
+
+In the case where a received `channel_announcement_2` message is received which
+does not have the optional `bitcoin_key_*` fields, the signature of the message
+should be verified as a 3-of-3 MuSig2 signature. The keys involved are:
+`node_id_1`, `node_id_2` and the taproot output key (`tr_output_key`) found in
+the channel's funding output specified by the provided `short_channel_id`.
+
+The full list of inputs required:
+- `node_id_1`
+- `node_id_2`
+- `tr_output_key`
+- `msg`: the serialised `channel_announcement_2` tlv stream.
+- `sig`: the 64-byte BIP340 signature found in the
+  `channel_announcement_signature` field of the `channel_announcement_2`
+  message. This signature must be parsed into `R` and `s` values as defined in
+  BIP327.
+
+The aggregate key can be calculated as follows:
+
+```
+P_agg = MuSig2.KeyAgg(MuSig2.KeySort(`node_id_1`, `node_id_2`, `tr_output_key`))
+```
+
+The signature can then be verified as follows:
+- Let `pk` = `bytes(P_agg)` where the `bytes` function is defined in BIP340.
+- Let `m` = `MsgHash("channel_announcement_2", "announcement_signature", msg)`
+- Use the BIP340 `Verify` function to determine if the signature is valid by
+  passing in `pk`, `m` and `sig`.
+
+### The 4-of-4 MuSig2 Scenario
+
+In the case where a received `channel_announcement_2` message is received which
+does have both the optional `bitcoin_key_*` fields, the signature of the message
+should be verified as a 4-of-4 MuSig2 signature. The keys involved are:
+`node_id_1`, `node_id_2`, `bitcoin_key_1` and `bitcoin_key_2`. The message may
+also optionally contain the `merkle_root_hash` field in this case.
+
+Before the actual signature verification is done, it should first be asserted
+that the taproot output key found in the funding output is in-fact made up of
+the provided bitcoin keys. This can be done as follows:
+
+First, calculate the aggregate key used as the internal key for the taproot
+output, `P_internal`:
+
+```
+P_internal = KeyAgg(MuSig2.KeySort(`bitcoin_key_1`, `bitcoin_key_2`))
+```
+
+- Let `P_o` be the taproot output key found on-chain in the funding output
+  referred to by the SCID.
+- if the `merkle_root_hash` field is _not_ provided:
+    - Fail the check if `P_internal != P_o`
+- otherwise, if the `merkle_root_hash` is provided:
+    - let `p` = `bytes(P_internal)`
+    - let `t = hash_TapTweak(p || merkle_root_hash)` where `hash_TapTweak` uses
+      the `hash_name(x)` method defined in BIP340.
+    - Fail if `P_o != P_internal + t*G`
+
+If the above check is successful, then it has been shown that the output key
+is constructed from the two provided bitcoin keys. So now the signature
+verification can be done.
+
+The full list of inputs required:
+- `node_id_1`
+- `node_id_2`
+- `bitcoin_key_1`
+- `bitcoin_key_2`
+- `msg`: the serialised `channel_announcement_2` tlv stream.
+- `sig`: the 64-byte BIP340 signature found in the
+  `channel_announcement_signature` field of the `channel_announcement_2`
+  message. This signature must be parsed into `R` and `s` values as defined in
+  BIP327.
+
+The aggregate key can be calculated as follows:
+
+```
+P_agg = MuSig2.KeyAgg(MuSig2.KeySort(`node_id_1`, `node_id_2`, `bitcoin_key_1`, `bitcoin_key_2`))
+```
+
+The signature can then be verified as follows:
+- Let `pk` = `bytes(P_agg)` where the `bytes` function is defined in BIP340.
+- Let `m` = `MsgHash("channel_announcement_2", "announcement_signature", msg)`
+- Use the BIP340 `Verify` function to determine if the signature is valid by
+  passing in `pk`, `m` and `sig`.
+
+## Signature Message Construction
 
 The following `MsgHash` function is defined which can be used to construct a
 32-byte message that can be used as a valid input to the [BIP-340][bip-340]
 signing and verification algorithms.
 
 _MsgHash:_
-  - _inputs_:
+- _inputs_:
     * `message_name`: UTF-8 string
     * `field_name`: UTF-8 string
     * `message`: byte array
 
-  - Let `tag` = "lightning" || `message_name` || `field_name`
-  - return SHA256(SHA256(`tag`) || SHA256(`tag`) || SHA256(`message`))
-
+- Let `tag` = "lightning" || `message_name` || `field_name`
+- return SHA256(SHA256(`tag`) || SHA256(`tag`) || SHA256(`message`))
 
 # Appendix B: Test Vectors
 
-TODO(elle)
+TODO
 
 # Acknowledgements
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -843,7 +843,9 @@ The receiving node:
 
 ### Query Messages
 
-TODO
+TODO: 
+    1. new first block height & block range fields in gossip_timestamp_range
+    2. add block-height query option (like timestamps query option)
 
 # Appendix A: Algorithms
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -906,6 +906,12 @@ multiple times, in order to change fees.
     1. type: 18 (`fee_proportional_millionths`)
     2. data:
         * [`tu32`:`fee_proportional_millionths`]
+    1. type: 20 (`inbound_fee_base_msat`)
+    2. data:
+        * [`tu32`:`inbound_fee_base_msat`]
+    1. type: 22 (`inbound_fee_proportional_millionths`)
+    2. data:
+        * [`tu32`:`inbound_fee_proportional_millionths`]
     1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -953,25 +959,49 @@ If the `permanant` bit is set, then the channel can be considered closed.
     - MUST be less than or equal to the channel capacity
     - MUST be less than or equal to the `max_htlc_value_in_flight_msat` it
       received from the peer in the `open_channel` message.
-- `fee_base_msat` is the base fee (in millisatoshis) that the node will charge
-  for an HTLC.
-- `fee_proportional_millionths` is the amount (in millionths of a satoshi) that
-  node will charge per transferred satoshi.
+- `fee_base_msat` is the **outbound** base fee (in millisatoshis) that the node
+  will charge for forwarding an HTLC out via this channel.
+- `fee_proportional_millionths` is the **outbound** amount (in millionths of a
+  satoshi) that the node will charge per transferred satoshi for forwarding an
+  HTLC out via this channel.
+- `inbound_fee_base_msat` is the additional base fee (in millisatoshis) that
+  the node charges for forwarding an HTLC that *arrived* on this channel,
+  regardless of which channel it is forwarded out via. This fee is positive
+  only (`tu32`), meaning a node MAY surcharge for receiving HTLCs over the
+  channel but MUST NOT advertise a discount.
+- `inbound_fee_proportional_millionths` is the additional amount (in millionths
+  of a satoshi) that the node charges per transferred satoshi for forwarding
+  an HTLC that arrived on this channel. Positive only, same constraint as
+  above.
+- The total fee a sender should expect for forwarding an HTLC `in_channel ->
+  out_channel` is:
+  ```
+  total_fee = out.fee_base_msat
+            + in.inbound_fee_base_msat
+            + amount_msat * (out.fee_proportional_millionths
+                            + in.inbound_fee_proportional_millionths)
+              / 1_000_000
+  ```
+  Where `in` is the `channel_update_2` of the channel the HTLC arrived on and
+  `out` is the `channel_update_2` of the channel the HTLC will be forwarded
+  out via, both belonging to the forwarding node.
 
 #### TLV Defaults
 
-For types 0, 6, 10, 12, 14, 16 and 18, the following defaults apply if the
-TLV is not present in the message:
+For types 0, 6, 10, 12, 14, 16, 18, 20 and 22, the following defaults apply if
+the TLV is not present in the message:
 
-| `channel_update_2` TLV Type        | Default Value                                                      | Comment                                                                                     |
-|------------------------------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| 0  (`chain_hash`)                  | `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000` | The hash of the genesis block of the mainnet Bitcoin blockchain.                            | 
-| 6  (`disable`)                     | empty                                                              |                                                                                             | 
-| 10 (`cltv_expiry_delta`)           | 80                                                                 |                                                                                             | 
-| 12 (`htlc_minimum_msat`)           | 1                                                                  |                                                                                             | 
-| 14 (`htlc_maximum_msat`)           | floor(channel capacity / 2)                                        | // TODO: remove this since makes encoding/decoding dependent on things outside the message? | 
-| 16 (`fee_base_msat`)               | 1000                                                               |                                                                                             | 
-| 18 (`fee_proportional_millionths`) | 1                                                                  |                                                                                             |
+| `channel_update_2` TLV Type                | Default Value                                                      | Comment                                                                                     |
+|--------------------------------------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| 0  (`chain_hash`)                          | `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000` | The hash of the genesis block of the mainnet Bitcoin blockchain.                            | 
+| 6  (`disable`)                             | empty                                                              |                                                                                             | 
+| 10 (`cltv_expiry_delta`)                   | 80                                                                 |                                                                                             | 
+| 12 (`htlc_minimum_msat`)                   | 1                                                                  |                                                                                             | 
+| 14 (`htlc_maximum_msat`)                   | floor(channel capacity / 2)                                        | // TODO: remove this since makes encoding/decoding dependent on things outside the message? | 
+| 16 (`fee_base_msat`)                       | 1000                                                               |                                                                                             | 
+| 18 (`fee_proportional_millionths`)         | 1                                                                  |                                                                                             |
+| 20 (`inbound_fee_base_msat`)               | 0                                                                  | No inbound surcharge.                                                                       |
+| 22 (`inbound_fee_proportional_millionths`) | 0                                                                  | No inbound surcharge.                                                                       |
 
 #### Requirements
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -610,47 +610,37 @@ The sender:
 
 The receiver:
 
-- MUST verify the integrity AND authenticity of the `channel_announcement_2`
-  message by verifying the signature. This verification will depend on the
-  channel type along with which fields have been set in the message.
+- If `short_channel_id`, `outpoint`, `capacity_satoshis`, `node_id_1`, `node_id_2` or `signature` are missing:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
 - Either the `short_channel_id` or the `outpoint` may be used to retrieve the
   channel's funding script. This can then be used to determine if the channel in
   question is a P2WSH channel or a P2TR channel.
 - If the channel is a P2WSH channel:
-    - The `bitcoin_key_1` and `bitcoin_key_2` fields MUST be set and the
-      `merkle_root_hash` field MUST NOT be set. The message should be ignored
-      otherwise.
-    - The `signature` field must be valid according to the rules defined in
-      [Verifying the `channel_announcement_2` signature](#verifying-the-channel_announcement_2-signature).
-- otherwise:
-    - The `bitcoin_key_1`, `bitcoin_key_2` and `merkle_root_hash` fields are
-      optional.
-    - The `signature` field must be valid according to the rules defined in
-      [Verifying the `channel_announcement_2` signature](#verifying-the-channel_announcement_2-signature).
-- If the `signature` is invalid:
+    - If `bitcoin_key_1` or `bitcoin_key_2` fields are missing, or `merkle_root_hash` is present:
+        - MUST ignore the message.
+- If `signature` field is not valid according to the rules defined in
+  [Verifying the `channel_announcement_2` signature](#verifying-the-channel_announcement_2-signature):
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
+- If `node_id_1` OR `node_id_2` are blacklisted:
+    - SHOULD ignore the message.
 - otherwise:
-    - if `node_id_1` OR `node_id_2` are blacklisted:
-        - SHOULD ignore the message.
+    - if the transaction referred to was NOT previously announced as a channel:
+        - SHOULD queue the message for rebroadcasting.
+          - MAY choose NOT to for messages longer than the minimum expected length.
+          - if it has previously received a valid `channel_announcement_2`, for
+            the same transaction, in the same block, but for a different
+            `node_id_1` or `node_id_2`:
+              - SHOULD blacklist the previous message's `node_id_1` and `node_id_2`,
+                as well as this `node_id_1` and `node_id_2` AND forget any channels
+                connected to them.
     - otherwise:
-        - if the transaction referred to was NOT previously announced as a
-          channel:
-            - SHOULD queue the message for rebroadcasting.
-            - MAY choose NOT to for messages longer than the minimum expected
-              length.
-        - if it has previously received a valid `channel_announcement_2`, for
-          the same transaction, in the same block, but for a different
-          `node_id_1` or `node_id_2`:
-            - SHOULD blacklist the previous message's `node_id_1` and `node_id_2`,
-              as well as this `node_id_1` and `node_id_2` AND forget any channels
-              connected to them.
-        - otherwise:
-            - SHOULD store this `channel_announcement`.
-
-- once its funding output has been spent OR reorganized out:
-    - SHOULD forget a channel after a 12-block delay.
+        - SHOULD store this `channel_announcement`.
+- Once this announced output has been spent OR reorganized out:
+    - SHOULD forget a channel after a 72-block delay.
 
 #### TLV Defaults
 
@@ -771,7 +761,7 @@ The following subtypes are defined:
 
 The sender:
 
-- MUST set TLV fields 0, 2 and 4.
+- MUST set TLV fields 0 (`features`), 2 (`block_height`) and 4 (`node_id`).
 - MUST set `signature` to a valid [BIP340][bip-340] signature for the
   `node_id` key. The message to be signed is
   `MsgHash("node_announcement_2", "signature", m)` where `m` is the
@@ -789,13 +779,13 @@ The sender:
   connections.
 - SHOULD ensure that any specified `ipv4_addr` AND `ipv6_addr` are routable
   addresses.
-- MUST not create a `ipv4_addr`, `ipv6_addr` or `dns_hostname` with a `port`
+- MUST not create a `ipv4_addr`, `ipv6_addr`, `tor_v3_address` or `dns_hostname` with a `port`
   equal to 0.
 - MUST set `features` according to [BOLT #9][bolt-9-features].
 
 The receiver:
 
-- If type 0, 2 or 4 is missing:
+- If type 0 (`features`), 2 (`block_height`), 4 (`node_id`) or 160 (`signature`) is missing:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
@@ -806,18 +796,18 @@ The receiver:
 - if `node_id` is NOT a valid compressed public key:
     - SHOULD send a `warning`.
     - MAY close the connection.
-    - MUST NOT process the message further.
+    - MUST ignore the message.
 - if `signature` is NOT a valid [BIP340][bip-340] signature (using
   `node_id` over the message):
     - SHOULD send a `warning`.
     - MAY close the connection.
-    - MUST NOT process the message further.
+    - MUST ignore the message.
 - if `features` field contains _unknown even bits_:
     - SHOULD NOT connect to the node.
     - Unless paying a [BOLT #11][bolt-11] invoice which does not have the same
       bit(s) set, MUST NOT attempt to send payments _to_ the node.
     - MUST NOT route a payment _through_ the node.
-- if `port` is equal to 0 for any `ipv6_addr` OR `ipv4_addr` OR `dns_hostname`:
+- if `port` is equal to 0 for any `ipv6_addr`, `ipv4_addr`, `tor_v3_address` OR `dns_hostname`:
     - SHOULD ignore that address.
 - if `node_id` is NOT previously known from a `channel_announcement` OR
   `channel_announcement_2` message, OR if `blockheight` is NOT greater than the
@@ -986,6 +976,10 @@ The origin node:
 
 The receiving node:
 
+- If `short_channel_id`, `block_height` or `signature` fields are missing:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
 - If the `short_channel_id` does NOT match a previous `channel_announcement_2`
   or `channel_announcement`, OR if the channel has been closed in the meantime:
     - MUST ignore `channel_update_2`s that do NOT correspond to one of its own
@@ -995,7 +989,7 @@ The receiving node:
 - if `signature` is NOT a valid [BIP340][bip-340] signature (using `node_id`
   over `MsgHash("channel_update_2", "signature", m)`):
     - SHOULD send a `warning` and close the connection.
-    - MUST NOT process the message further.
+    - MUST ignore the message.
 
 ### Query Messages
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -235,7 +235,7 @@ The following convenient types are defined:
 ### Pure TLV messages
 
 All the messages defined in this document are pure TLV streams. The signed TLV
-range is defined as the inclusive ranges: 0 to 159 and 1000000000 to 2999999999.
+range is defined as the inclusive ranges: 0 to 239 and 1000000000 to 2999999999.
 
 When a signature TLV in a message commits to "the message" via
 `MsgHash(message_name, field_name, m)` (see
@@ -245,7 +245,7 @@ falls within the signed range, in strictly ascending `type` order**. Each
 record is serialised as `<bigsize type><bigsize length><value>` exactly as it
 appears on the wire. `m` does **not** include the message-type prefix, any
 outer length prefix, or any TLV records whose `type` is outside the signed
-range (most notably the signature TLV itself, which lives at type 160). TLVs
+range (most notably the signature TLV itself, which lives at type 240). TLVs
 that are absent from the wire message contribute nothing to `m`, even if a
 default value is defined for them.
 
@@ -554,7 +554,7 @@ announced its fee levels and expiry, using `channel_update_2`.
     2. data:
         * [`sha256`:`txid`]
         * [`u16`:`index`]
-    1. type: 160 (`signature`)
+    1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
 
@@ -696,7 +696,7 @@ by multiple keys since MuSig2 can be used to construct the single signature.
     1. type: 11 (`dns_hostnames`)
     2. data:
         * [`...*dns_hostname`:`dns_hostnames`]
-    1. type: 160 (`signature`)
+    1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
 
@@ -785,7 +785,7 @@ The sender:
 
 The receiver:
 
-- If type 0 (`features`), 2 (`block_height`), 4 (`node_id`) or 160 (`signature`) is missing:
+- If type 0 (`features`), 2 (`block_height`), 4 (`node_id`) or 240 (`signature`) is missing:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
@@ -875,7 +875,7 @@ multiple times, in order to change fees.
     1. type: 18 (`fee_proportional_millionths`)
     2. data:
         * [`tu32`:`fee_proportional_millionths`]
-    1. type: 160 (`signature`)
+    1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -178,15 +178,33 @@ A block height based timestamp results in more natural rate limiting for gossip
 messages: nodes are allowed to send at most one announcement and update per
 block. To allow for bursts, nodes are encouraged not to use the latest block
 height for their latest announcements/updates but rather to backdate and use
-older block heights that they have not used in an announcement/update. There of
-course needs to be a limit on the start block height that the node can use:
-for `channel_update_2` messages, the lowest allowed `blockheight` is the block
-height in which the channel funding transaction was mined and all updates after
-the initial one must have increasing block heights. Nodes are then responsible
-for building up their own timestamp buffer: if they want to be able to send
-multiple `channel_update_2` messages per block, then they will need to ensure
-that there are blocks during which they do not broadcast any updates. This
-provides an incentive for nodes not to spam the network with too many updates.
+older block heights that they have not used in an announcement/update.
+Backdating only applies to messages whose `block_height` is chosen by the
+sender, namely `channel_update_2` and `node_announcement_2`;
+`channel_announcement_2` is tied to its on-chain funding transaction and has
+no sender-chosen timestamp.
+
+The backdate range is bounded on both sides. The upper bound is the current
+best block height. The lower bound is the larger of:
+
+- a per-message anchor: the funding block of the channel for
+  `channel_update_2`, or the funding block of the oldest channel the node has
+  advertised via `channel_announcement_2` for `node_announcement_2`; and
+- `current_block_height − max_backdate_blocks`.
+
+Without the second bound, a node whose anchor is far in the past (e.g. a
+channel funded months ago) could legally emit one update per intervening
+block, defeating the rate-limit story. With it, the usable backdate range
+collapses to the window peers will actually accept and relay anyway.
+
+`max_backdate_blocks` is defined as `2016` blocks (approximately
+two weeks at the Bitcoin block interval of ten minutes), chosen to match the
+staleness window used for legacy gossip in [BOLT #7][bolt-7]. Within those
+bounds nodes are responsible for building up their own timestamp buffer: if
+they want to be able to send multiple messages per block, they need to
+ensure that there are blocks during which they do not broadcast any
+updates. This provides an incentive for nodes not to spam the network with
+too many updates.
 
 ### Simplifies Channel Announcement Queries
 
@@ -919,9 +937,13 @@ The sender:
 - If the node sets the `alias`:
     - MUST use 32 utf8 characters or less.
 - MUST set `block_height` to be greater than that of any previous
-  `node_announcement_2` it has previously created. The `blockheight` should
-  always be greater than or equal to funding block of the oldest channel that
-  the node has advertised via `channel_announcement_2`.
+  `node_announcement_2` it has previously created.
+- The `block_height` SHOULD be greater than or equal to the funding block of
+  the oldest channel that the node has advertised via
+  `channel_announcement_2`.
+- MUST NOT set `block_height` less than
+  `current_block_height − max_backdate_blocks` (see
+  [Rate Limiting](#rate-limiting)).
 - SHOULD set an address type (`ipv4_address`, `ipv6_address`, `tor_v3_address`
   and/or `dns_hostname`) for each public network address that expects incoming
   connections.
@@ -960,6 +982,10 @@ The receiver:
 - if `node_id` is NOT previously known from a `channel_announcement` OR
   `channel_announcement_2` message, OR if `blockheight` is NOT greater than the
   last-received `node_announcement_2` from this `node_id`:
+    - SHOULD ignore the message.
+- if `block_height` is less than
+  `current_block_height − max_backdate_blocks` (see
+  [Rate Limiting](#rate-limiting)):
     - SHOULD ignore the message.
 - otherwise:
     - if `block_height` is greater than the last-received `node_announcement_2`
@@ -1062,8 +1088,11 @@ If the `permanant` bit is set, then the channel can be considered closed.
 - `block_height` is the timestamp associated with the message. A node may not
   send two `channel_update` messages with the same `block_height`. The
   `block_height` must also be greater than or equal to the block height
-  indicated by the `short_channel_id` used in the `channel_announcement_2` and
-  must not be greater than current best block height.
+  indicated by the `short_channel_id` used in the `channel_announcement_2`,
+  must not be less than
+  `current_block_height − max_backdate_blocks` (see
+  [Rate Limiting](#rate-limiting)), and must not be greater than the current
+  best block height.
 - The `disable` bit field can be used to advertise to the network that a channel
   is disabled and that it should not be used for routing. The individual
   `disable_flags` bits can be used to communicate more fine-grained information.
@@ -1181,6 +1210,10 @@ The receiving node:
   `signing_node_id` over `MsgHash("channel_update_2", "signature", m)`):
     - SHOULD send a `warning` and close the connection.
     - MUST ignore the message.
+- if `block_height` is less than
+  `current_block_height − max_backdate_blocks` (see
+  [Rate Limiting](#rate-limiting)):
+    - SHOULD ignore the message.
 
 ### Query Messages
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -772,9 +772,6 @@ The sender:
   `node_announcement_2` it has previously created. The `blockheight` should
   always be greater than or equal to funding block of the oldest channel that
   the node has advertised via `channel_announcement_2`.
-- If the node wishes to announce its willingness to accept incoming network
-  connections:
-    - SHOULD set at least one of types 7-10.
 - SHOULD set an address type (`ipv4_address`, `ipv6_address`, `tor_v3_address`
   and/or `dns_hostname`) for each public network address that expects incoming
   connections.
@@ -808,7 +805,7 @@ The receiver:
     - Unless paying a [BOLT #11][bolt-11] invoice which does not have the same
       bit(s) set, MUST NOT attempt to send payments _to_ the node.
     - MUST NOT route a payment _through_ the node.
-- if `port` is equal to 0 for any `ipv6_addr` OR `ipv4_addr` OR `hostname`:
+- if `port` is equal to 0 for any `ipv6_addr` OR `ipv4_addr` OR `dns_hostname`:
     - SHOULD ignore that address.
 - if `node_id` is NOT previously known from a `channel_announcement` OR
   `channel_announcement_2` message, OR if `blockheight` is NOT greater than the

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -522,7 +522,7 @@ announced its fee levels and expiry, using `channel_update_2`.
         * [`short_channel_id`:`short_channel_id`]
     1. type: 6 (`capacity_satoshis`)
     2. data:
-        * [`u64`:`capacity_satoshis`]
+        * [`tu64`:`capacity_satoshis`]
     1. type: 8 (`node_id_1`)
     2. data:
         * [`point`:`node_id_1`]
@@ -628,7 +628,7 @@ The receiver:
             - SHOULD queue the message for rebroadcasting.
             - MAY choose NOT to for messages longer than the minimum expected
               length.
-        - if it has previously received a valid `channel_announcement_v2`, for
+        - if it has previously received a valid `channel_announcement_2`, for
           the same transaction, in the same block, but for a different
           `node_id_1` or `node_id_2`:
             - SHOULD blacklist the previous message's `node_id_1` and `node_id_2`,
@@ -668,32 +668,32 @@ by multiple keys since MuSig2 can be used to construct the single signature.
 1. `tlv_stream`: `node_announcement_2_tlvs`
 2. types:
     1. type: 0 (`features`)
+    2. data:
+        * [`...*byte`:`features`]
     1. type: 1 (`color`)
     2. data:
         * [`rgb_color`:`rgb_color`]
-    2. data:
-        * [`...*byte`: `features`]
     1. type: 2 (`block_height`)
+    2. data:
+        * [`u32`:`block_height`]
     1. type: 3 (`alias`)
     2. data:
         * [`...*utf8`:`alias`]
-    2. data:
-        * [`u32`: `block_height`]
     1. type: 4 (`node_id`)
     2. data:
         * [`point`:`node_id`]
     1. type: 5 (`ipv4_addrs`)
     2. data:
-        * [`...*ipv4_addr`: `ipv4_addresses`]
+        * [`...*ipv4_addr`:`ipv4_addresses`]
     1. type: 7 (`ipv6_addrs`)
     2. data:
-        * [`...*ipv6_addr`: `ipv6_addresses`]
+        * [`...*ipv6_addr`:`ipv6_addresses`]
     1. type: 9 (`tor_v3_addrs`)
     2. data:
-        * [`...*tor_v3_addr`: `tor_v3_addresses`]
+        * [`...*tor_v3_addr`:`tor_v3_addresses`]
     1. type: 11 (`dns_hostnames`)
     2. data:
-        * [`...*dns_hostname`: `dns_hostnames`]
+        * [`...*dns_hostname`:`dns_hostnames`]
     1. type: 160 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -866,16 +866,16 @@ multiple times, in order to change fees.
         * [`u16`:`cltv_expiry_delta`]
     1. type: 12 (`htlc_minimum_msat`)
     2. data:
-        * [`u64`:`htlc_minimum_msat`]
+        * [`tu64`:`htlc_minimum_msat`]
     1. type: 14 (`htlc_maximum_msat`)
     2. data:
-        * [`u64`:`htlc_maximum_msat`]
+        * [`tu64`:`htlc_maximum_msat`]
     1. type: 16 (`fee_base_msat`)
     2. data:
-        * [`u32`:`fee_base_msat`]
+        * [`tu32`:`fee_base_msat`]
     1. type: 18 (`fee_proportional_millionths`)
     2. data:
-        * [`u32`:`fee_proportional_millionths`]
+        * [`tu32`:`fee_proportional_millionths`]
     1. type: 160 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -984,7 +984,7 @@ The receiving node:
 - SHOULD accept `channel_update_2`s for its own channels (even if non-public),
   in order to learn the associated origin nodes' forwarding parameters.
 - if `signature` is NOT a valid [BIP340][bip-340] signature (using `node_id`
-  over the message):
+  over `MsgHash("channel_update_2", "signature", m)`):
     - SHOULD send a `warning` and close the connection.
     - MUST NOT process the message further.
 
@@ -1014,14 +1014,14 @@ they will each have the following information:
 - `node_2` will know:
     - `bitcoin_priv_key_2`, `node_ID_priv_key_2`,
     - `bitcoin_key_1`,
-    - `node_ID_1`,
+    - `node_ID_2`,
     - `announcement_node_secnonce_2` and `announcement_node_pubnonce_2`,
     - `announcement_bitcoin_secnonce_2` and `announcement_bitcoin_pubnonce_2`,
     - `announcement_node_pubnonce_1`,
     - `announcement_bitcoin_pubnonce_1`,
 
 With the above information, both nodes can now start calculating the partial
-signatures that will be exchanged in the `announcement_signatures_v2` message.
+signatures that will be exchanged in the `announcement_signatures_2` message.
 
 Firstly, the aggregate public key, `P_agg`, that the signature will be valid for
 can be calculated as follows:
@@ -1246,7 +1246,8 @@ The signature can then be verified as follows:
 
 The following `MsgHash` function is defined which can be used to construct a
 32-byte message that can be used as a valid input to the [BIP-340][bip-340]
-signing and verification algorithms.
+signing and verification algorithms. This is the same tagged-hash format used
+by [BOLT #12][bolt-12].
 
 _MsgHash:_
 - _inputs_:
@@ -1277,6 +1278,7 @@ ideas mentioned in the following references:
 
 [bolt-7]: ./07-routing-gossip.md
 [bolt-3]: ./03-transactions.md
+[bolt-12]: ./12-offer-encoding.md
 [bolt-7-alias-security]: ./07-routing-gossip.md#security-considerations-for-node-aliases
 [bolt-9-features]: ./09-features.md#bolt-9-assigned-feature-flags
 [bolt-11]: ./11-payment-encoding.md
@@ -1287,14 +1289,14 @@ ideas mentioned in the following references:
 [bip-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 [bip-340-verify]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#verification
 [simple-taproot-chans]: https://github.com/lightning/bolts/pull/995
-[musig-keysort]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#key-sorting
-[musig-keyagg]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#key-aggregation
-[musig-signing]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#signing
+[musig-keysort]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#key-sorting
+[musig-keyagg]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#key-aggregation
+[musig-signing]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#signing
 [bip86-tweak]: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#address-derivation
-[bip-musig2]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki
-[musig-session-ctx]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#session-context
-[musig-notation]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#notation
-[musig-partial-sig-agg]: https://github.com/jonasnick/bips/blob/musig2/bip-musig2.mediawiki#partial-signature-aggregation
+[bip-musig2]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki
+[musig-session-ctx]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#session-context
+[musig-notation]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#notation
+[musig-partial-sig-agg]: https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#partial-signature-aggregation
 [secp256k1]: https://www.secg.org/sec2-v2.pdf
 [punycode]: https://en.wikipedia.org/wiki/Punycode
 [prop224]: https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -984,6 +984,8 @@ The origin node:
   any channel advertised via `channel_announcement_2`.
 - MUST NOT send a created `channel_update_2` before `channel_ready` has been
   received.
+- MUST encode `short_channel_id` in the `sciddir` form of
+  [`sciddir_or_pubkey`][bolt-1-types] (the `pubkey` form MUST NOT be used).
 - MUST set the `short_channel_id` direction byte to `0` if it is `node_id_1`
   in the corresponding `channel_announcement_2`, or to `1` if it is `node_id_2`.
 - For an unannounced channel (i.e. one where `announcement_signatures_2` has

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -445,8 +445,10 @@ This message can be sent in two cases:
     1. type: 2 (`short_channel_id`)
     2. data:
         * [`short_channel_id`:`short_channel_id`]
-    1. type: 4 (`partial_signature`)
-        * [`partial_signature`:`partial_signature`]
+    1. type: 4 (`partial_signatures`)
+    2. data:
+        * [`partial_signature`:`node_partial_signature`]
+        * [`partial_signature`:`bitcoin_partial_signature`]
 
 
 #### Requirements:
@@ -464,12 +466,14 @@ A node:
     - MUST send the `announcement_signatures_2` message once a `channel_ready`
       message containing the announcement nonces has been sent and received AND
       the funding transaction has at least six confirmations.
-    - MUST set the `partial_signature` field to the 32-byte `partial_sig` value
-      of the partial signature calculated as described in [Partial Signature
-      Calculation](#partial-signature-calculation). The message to be signed is
-      `MsgHash("channel_announcement", "signature", m)` where `m` is the
-      serialisation of the `channel_announcement_2` message tlv stream (see the
-      [`MsgHash`](#signature-message-construction) definition).
+    - MUST set `node_partial_signature` and `bitcoin_partial_signature` to the
+      two standard MuSig2 partial signatures it produced (one with its
+      `node_ID` key, one with its `bitcoin_key`), as described in
+      [Partial Signature Calculation](#partial-signature-calculation). The
+      message signed by both is `MsgHash("channel_announcement_2", "signature",
+      m)` where `m` is the canonical signed-range TLV byte sequence of the
+      `channel_announcement_2` message (see
+      [`MsgHash`](#signature-message-construction)).
 - otherwise if the `option_gossip_announce_private` bit has been negotiated:
     - MAY send the `announcement_signatures_2` message at any point during the
       channel's lifetime with the same constraints as defined above.
@@ -488,8 +492,8 @@ A recipient node:
 - if the `short_channel_id` is NOT correct:
     - SHOULD send a `warning` and close the connection, or send an
       `error` and fail the channel.
-- if the `partial_signature` is NOT valid as
-  per [Partial Signature Verification](#partial-signature-verification):
+- if either `node_partial_signature` or `bitcoin_partial_signature` is NOT
+  valid as per [Partial Signature Verification](#partial-signature-verification):
     - MAY send a `warning` and close the connection, or send an
       `error` and fail the channel.
 - if it has sent AND received a valid `announcement_signatures_2` message:
@@ -500,13 +504,14 @@ A recipient node:
 
 #### Rationale
 
-The message contains the necessary partial signature, by the sender, that the
-recipient will be able to combine with their own partial signature to construct
-the signature to put in the `channel_announcement_2` message. Unlike the legacy
-`announcement_signatures` message, `announcement_signatures_2` only has one
-signature field. This field is a MuSig2 partial signature which is the
-aggregation of the two signatures that the sender would have created (one for
-`bitcoin_key_x` and another for `node_ID_x`).
+The message contains the two MuSig2 partial signatures the sender produced —
+one with its `node_ID` key and one with its `bitcoin_key` — bundled together
+in a single 64-byte TLV. The recipient verifies each partial signature with
+the standard MuSig2 `PartialSigVerify` routine, then once both peers'
+contributions are available the four partial signatures can be aggregated
+into the final BIP340 signature placed in `channel_announcement_2`. Carrying
+the two partial sigs raw — rather than pre-aggregated into one 32-byte value —
+keeps the verifier on stock MuSig2 primitives.
 
 ### The `channel_announcement_2` Message
 
@@ -1127,86 +1132,70 @@ of the `Session Context`, which we will call `session_ctx`, can be defined:
 - `v`: 0
 - `m`: `msg`
 
-Both peers, `node_1` and `node_2` will need to construct two partial signatures.
-One for their `bitcoin_key` and one for their `node_ID` and aggregate those.
+Both peers, `node_1` and `node_2`, each produce two standard MuSig2 partial
+signatures and send both in their `announcement_signatures_2` message: one
+with their `node_ID` private key and one with their `bitcoin_key` private key.
 
 - `node_1`:
     - calculates a partial signature for `node_ID_1` as follows:
        ```
-       partial_sig_node_1 = MuSig2.Sign(announcement_node_secnonce_1, node_ID_priv_key_1, session_ctx) 
+       node_partial_signature_1 = MuSig2.Sign(announcement_node_secnonce_1, node_ID_priv_key_1, session_ctx)
        ```
-    - calculates a partial signature for `bitcoin_ID_1` as follows:
+    - calculates a partial signature for `bitcoin_key_1` as follows:
        ```
-       partial_sig_bitcoin_1 = MuSig2.Sign(announcement_bitcoin_secnonce_1, bitcoin_priv_key_1, session_ctx) 
+       bitcoin_partial_signature_1 = MuSig2.Sign(announcement_bitcoin_secnonce_1, bitcoin_priv_key_1, session_ctx)
        ```
-    - calculates `partial_sig_1` as follows:
-       ```
-       partial_sig_1 =  MuSig2.PartialSigAgg(partial_sig_node_1, partial_sig_bitcoin_1, session_ctx)
-       ```
+    - sends both in the `partial_signatures` TLV of `announcement_signatures_2`.
 
 - `node_2`:
     - calculates a partial signature for `node_ID_2` as follows:
        ```
-       partial_sig_node_2 = MuSig2.Sign(announcement_node_secnonce_2, node_ID_priv_key_2, session_ctx) 
+       node_partial_signature_2 = MuSig2.Sign(announcement_node_secnonce_2, node_ID_priv_key_2, session_ctx)
        ```
-    - calculates a partial signature for `bitcoin_ID_2` as follows:
+    - calculates a partial signature for `bitcoin_key_2` as follows:
        ```
-       partial_sig_bitcoin_2 = MuSig2.Sign(announcement_bitcoin_secnonce_2, bitcoin_priv_key_2, session_ctx) 
+       bitcoin_partial_signature_2 = MuSig2.Sign(announcement_bitcoin_secnonce_2, bitcoin_priv_key_2, session_ctx)
        ```
-    - calculates `partial_sig_2` as follows:
-       ```
-       partial_sig_2 =  MuSig2.PartialSigAgg(partial_sig_node_2, partial_sig_bitcoin_2, session_ctx)
-       ```     
+    - sends both in the `partial_signatures` TLV of `announcement_signatures_2`.
 
-Note that since there are no tweaks involved in this MuSig2 signing flow,
-signature aggregation is simply the addition of the two signatures:
+Once both peers have exchanged `announcement_signatures_2`, each node has all
+four partial signatures and can produce the final BIP340 signature placed in
+`channel_announcement_2` using the standard MuSig2 aggregation:
 
 ```
-    partial_sig = (partial_sig_node + partial_sig_bitcoin) % n
+final_sig = MuSig2.PartialSigAgg(
+    [node_partial_signature_1, bitcoin_partial_signature_1,
+     node_partial_signature_2, bitcoin_partial_signature_2],
+    session_ctx)
 ```
-
-Where `n` is the [secp256k1][secp256k1] curve order.
 
 ## Partial Signature Verification
 
-Since the partial signature put in `announcement_signatures_2` is the addition
-of two of four signatures required to make up the final MuSig2 signature, the
-verification of the partial signature is slightly different from what is
-specified in the MuSig2 spec. The slightly adjusted algorithm will be defined
-here. The notation used is the same as defined in the [MuSig2][musig-notation]
-spec.
+Each `announcement_signatures_2` message carries two standard MuSig2 partial
+signatures from the peer. Both are verified using the unmodified
+`PartialSigVerify` routine from the [MuSig2][bip-musig2] spec.
 
-The inputs are:
+The inputs available to the verifier are:
 
-- `partial_sig` sent by the peer in the `announcement_signatures_2` message.
-- The `node_ID` and `bitcoin_key` of the peer.
-- The `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce` sent by
-  the peer in the `channel_ready` message.
-- The `session_ctx` as shown
-  in [Partial Signature Calculation](#partial-signature-calculation).
+- `node_partial_signature` and `bitcoin_partial_signature` from the
+  `partial_signatures` TLV of the received `announcement_signatures_2`.
+- The peer's `node_ID` and `bitcoin_key`.
+- The peer's `announcement_node_pubnonce` and `announcement_bitcoin_pubnonce`
+  (received earlier in `channel_ready`).
+- The `session_ctx` defined in
+  [Partial Signature Calculation](#partial-signature-calculation).
 
-Verification steps:
+Verification:
 
-Note that the `GetSessionValues` and `GetSessionKeyAggCoeff` definitions can be
-found in the [MuSig2][musig-session-ctx] spec.
+- Run `MuSig2.PartialSigVerify(node_partial_signature, [announcement_node_pubnonce], [node_ID], [], session_ctx)`.
+  Fail if it returns false.
+- Run `MuSig2.PartialSigVerify(bitcoin_partial_signature, [announcement_bitcoin_pubnonce], [bitcoin_key], [], session_ctx)`.
+  Fail if it returns false.
 
-- Let `(Q, _, _, b, R, e) = GetSessionValues(session_ctx)`
-- Let `s = int(psig); fail if s >= n`
-- Let `R_n1 = cpoint(announcement_node_pubnonce[0:33])`
-- Let `R_n2 = cpoint(announcement_node_pubnonce[33:66])`
-- Let `R_b1 = cpoint(announcement_bitcoin_pubnonce[0:33])`
-- Let `R_b2 = cpoint(announcement_bitcoin_pubnonce[33:66])`
-- Let `R_1 = R_n1 + R_b1`
-- Let `R_2 = b*(R_n2 + R_b2)`
-- Let `R_e' = R_1 + R_2`
-- Let `R_e = R_e'` if `has_even_y(R)`, otherwise let `R_e = -R_e'`
-- Let `P_n = node_ID`
-- Let `P_b = bitcoin_key`
-- Let `a_n = GetSessionKeyAggCoeff(session_ctx, P_n)`
-- Let `a_b = GetSessionKeyAggCoeff(session_ctx, P_b)`
-- Let `P = a_n*P_n + a_b*P_b`
-- Let `g = 1` if `has_even_y(Q)`, otherwise `let g = -1 mod n`
-- Fail if `s*G != R_e + e*g*P`
+(The exact `PartialSigVerify` argument list depends on the MuSig2 library
+in use; the point is that each partial signature is checked individually
+against the signer's pubkey, the signer's pubnonce, and the shared
+`session_ctx` — no custom verifier is required.)
 
 ## Signature Message Construction
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -546,7 +546,7 @@ announced its fee levels and expiry, using `channel_update_2`.
         * [`point`:`bitcoin_key_2`]
     1. type: 16 (`merkle_root_hash`)
     2. data:
-        * [`32*byte`:`hash`]
+        * [`sha256`:`hash`]
     1. type: 18 (`outpoint`)
     2. data:
         * [`sha256`:`txid`]

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -867,9 +867,10 @@ The security considerations for node aliases mentioned in
 
 After a channel has been initially announced via `channel_announcement_2`, each
 side independently announces the fees and minimum expiry delta it requires to
-relay HTLCs through this channel. Each uses the 8-byte short channel id that
-matches the `channel_announcement_2` and the `second_peer` field to
-indicate which end of the channel it's on (origin or final). A node can do this
+relay HTLCs through this channel. Each identifies the channel by reusing the
+[`sciddir_or_pubkey`][bolt-1-types] type (constrained to the `sciddir` form),
+which packs the 8-byte channel id together with a one-byte direction tag that
+indicates which end of the channel sent the update. A node can do this
 multiple times, in order to change fees.
 
 1. type: 271 (`channel_update_2`)
@@ -883,14 +884,13 @@ multiple times, in order to change fees.
         * [`chain_hash`:`chain_hash`]
     1. type: 2 (`short_channel_id`)
     2. data:
-        * [`short_channel_id`:`short_channel_id`]
+        * [`sciddir_or_pubkey`:`short_channel_id`]
     1. type: 4 (`block_height`)
     2. data:
         * [`u32`:`block_height`]
     1. type: 6 (`disable_flags`)
     2. data:
         * [`byte`:`disable_flags`]
-    1. type: 8 (`second_peer`)
     1. type: 10 (`cltv_expiry_delta`)
     2. data:
         * [`u16`:`cltv_expiry_delta`]
@@ -930,8 +930,12 @@ If the `permanant` bit is set, then the channel can be considered closed.
 
 - The `chain_hash` is used to identify the blockchain containing the channel
   being referred to.
-- `short_channel_id` is the unique identifier of the channel. If the channel is
-  unannounced, then this may be set to an agreed upon alias.
+- `short_channel_id` is a [`sciddir_or_pubkey`][bolt-1-types] in the `sciddir`
+  form (the `pubkey` form MUST NOT be used). It is the 9-byte concatenation of
+  a direction byte and the 8-byte channel id from the corresponding
+  `channel_announcement_2`: the direction byte is `0` when the update is from
+  `node_id_1` and `1` when from `node_id_2`. If the channel is unannounced,
+  the channel id portion may be set to an agreed-upon alias.
 - `block_height` is the timestamp associated with the message. A node may not
   send two `channel_update` messages with the same `block_height`. The
   `block_height` must also be greater than or equal to the block height
@@ -940,10 +944,6 @@ If the `permanant` bit is set, then the channel can be considered closed.
 - The `disable` bit field can be used to advertise to the network that a channel
   is disabled and that it should not be used for routing. The individual
   `disable_flags` bits can be used to communicate more fine-grained information.
-- The `second_peer` is used to indicate which node in the channel node pair has
-  created and signed this message. If present, the node was `node_id_2` in the
-  `channel_announcment_2`, otherwise the node is `node_id_1` in the
-  `channel_announcement_2` message.
 - `cltv_expiry_delta` is the number of blocks that the node will subtract from
   an incoming HTLC's `cltv_expiry`.
 - `htlc_minimum_msat` is the minimum HTLC value (in millisatoshi) that the
@@ -984,18 +984,21 @@ The origin node:
   any channel advertised via `channel_announcement_2`.
 - MUST NOT send a created `channel_update_2` before `channel_ready` has been
   received.
+- MUST set the `short_channel_id` direction byte to `0` if it is `node_id_1`
+  in the corresponding `channel_announcement_2`, or to `1` if it is `node_id_2`.
 - For an unannounced channel (i.e. one where `announcement_signatures_2` has
   not been exchanged):
     - MAY create a `channel_update_2` to communicate the channel parameters to
       the channel peer.
-    - MUST set the `short_channel_id` to either an `alias` it has received from
-      the peer, or the real channel `short_channel_id`.
+    - MUST set the channel-id portion of `short_channel_id` to either an
+      `alias` it has received from the peer, or the real channel
+      `short_channel_id`.
     - MUST NOT forward such a `channel_update_2` to other peers, for privacy
       reasons.
 - For announced channels:
-    - MUST set `chain_hash` AND `short_channel_id` to match the 32-byte hash AND
-      8-byte channel ID that uniquely identifies the channel specified in the
-      `channel_announcement_2` message.
+    - MUST set `chain_hash` AND the channel-id portion of `short_channel_id`
+      to match the 32-byte hash AND 8-byte channel ID that uniquely identifies
+      the channel specified in the `channel_announcement_2` message.
 - MUST set `signature` to a valid [BIP340][bip-340] signature for its own
   `node_id` key. The message to be signed is
   `MsgHash("channel_update_2", "signature", m)` where `m` is the serialised
@@ -1011,14 +1014,22 @@ The receiving node:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
-- If the `short_channel_id` does NOT match a previous `channel_announcement_2`
-  or `channel_announcement`, OR if the channel has been closed in the meantime:
+- If `short_channel_id` is not in the `sciddir` form (i.e. its first byte is
+  neither `0` nor `1`):
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
+- Let `signing_node_id` be `node_id_1` if the `short_channel_id` direction
+  byte is `0`, and `node_id_2` otherwise.
+- If the channel-id portion of `short_channel_id` does NOT match a previous
+  `channel_announcement_2` or `channel_announcement`, OR if the channel has
+  been closed in the meantime:
     - MUST ignore `channel_update_2`s that do NOT correspond to one of its own
       channels.
 - SHOULD accept `channel_update_2`s for its own channels (even if non-public),
   in order to learn the associated origin nodes' forwarding parameters.
-- if `signature` is NOT a valid [BIP340][bip-340] signature (using `node_id`
-  over `MsgHash("channel_update_2", "signature", m)`):
+- if `signature` is NOT a valid [BIP340][bip-340] signature (using
+  `signing_node_id` over `MsgHash("channel_update_2", "signature", m)`):
     - SHOULD send a `warning` and close the connection.
     - MUST ignore the message.
 
@@ -1200,6 +1211,7 @@ ideas mentioned in the following references:
   Channel Announcements + Proof Verification which expands on the details of how
   taproot channel verification should work.
 
+[bolt-1-types]: ./01-messaging.md#fundamental-types
 [bolt-7]: ./07-routing-gossip.md
 [bolt-3]: ./03-transactions.md
 [bolt-12]: ./12-offer-encoding.md

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -237,6 +237,18 @@ The following convenient types are defined:
 All the messages defined in this document are pure TLV streams. The signed TLV
 range is defined as the inclusive ranges: 0 to 159 and 1000000000 to 2999999999.
 
+When a signature TLV in a message commits to "the message" via
+`MsgHash(message_name, field_name, m)` (see
+[Signature Message Construction](#signature-message-construction)), `m` is the
+**canonical concatenation of every TLV record in the message whose `type`
+falls within the signed range, in strictly ascending `type` order**. Each
+record is serialised as `<bigsize type><bigsize length><value>` exactly as it
+appears on the wire. `m` does **not** include the message-type prefix, any
+outer length prefix, or any TLV records whose `type` is outside the signed
+range (most notably the signature TLV itself, which lives at type 160). TLVs
+that are absent from the wire message contribute nothing to `m`, even if a
+default value is defined for them.
+
 ### Feature Bits
 
 The proposed gossip upgrade is quite large and will require a lot of new code
@@ -1250,7 +1262,8 @@ _MsgHash:_
 - _inputs_:
     * `message_name`: UTF-8 string
     * `field_name`: UTF-8 string
-    * `message`: byte array
+    * `message`: byte array — the canonical signed-range TLV byte sequence
+      defined in [Pure TLV messages](#pure-tlv-messages).
 
 - Let `tag` = "lightning" || `message_name` || `field_name`
 - return SHA256(SHA256(`tag`) || SHA256(`tag`) || SHA256(`message`))

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -30,9 +30,6 @@ and that use a pure TLV based structure.
 * [Appendix A: Algorithms](#appendix-a-algorithms)
     * [Partial Signature Calculation](#partial-signature-calculation)
     * [Partial Signature Verification](#partial-signature-verification)
-    * [Verifying the `channel_announcement_2` signature](#verifying-the-channelannouncement2-signature)
-        * [The 3-of-3 MuSig2 Scenario](#the-3-of-3-musig2-scenario)
-        * [The 4-of-4 MuSig2 Scenario](#the-4-of-4-musig2-scenario)
     * [Signature Message Construction](#signature-message-construction)
 * [Appendix B: Test Vectors](#appendix-b-test-vectors)
 * [Acknowledgements](#acknowledgements)
@@ -609,23 +606,28 @@ The sender:
   message.
 
 The receiver:
-
-- If `short_channel_id`, `outpoint`, `capacity_satoshis`, `node_id_1`, `node_id_2` or `signature` are missing:
+- if `short_channel_id`, `outpoint`, `capacity_satoshis`, `node_id_1`, `node_id_2` or `signature` are missing:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
-- Either the `short_channel_id` or the `outpoint` may be used to retrieve the
-  channel's funding script. This can then be used to determine if the channel in
-  question is a P2WSH channel or a P2TR channel.
-- If the channel is a P2WSH channel:
-    - If `bitcoin_key_1` or `bitcoin_key_2` fields are missing, or `merkle_root_hash` is present:
-        - MUST ignore the message.
-- If `signature` field is not valid according to the rules defined in
-  [Verifying the `channel_announcement_2` signature](#verifying-the-channel_announcement_2-signature):
+- MUST use either the `short_channel_id` or the `outpoint` to retrieve the channel's claimed funding output:
+  - if no such unspent output is found:
+    - MAY send a `warning`.
+    - MUST ignore the message.
+    - SHOULD NOT close the connection.
+- if the output amount is less than `capacity_satoshis`:
     - SHOULD send a `warning`.
     - MAY close the connection.
     - MUST ignore the message.
-- If `node_id_1` OR `node_id_2` are blacklisted:
+- if the output does not correspond to both `short_channel_id` and `outpoint`:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
+- if channel announcement validation (see below) fails:
+    - SHOULD send a `warning`.
+    - MAY close the connection.
+    - MUST ignore the message.
+- if `node_id_1` OR `node_id_2` are blacklisted:
     - SHOULD ignore the message.
 - otherwise:
     - if the transaction referred to was NOT previously announced as a channel:
@@ -641,6 +643,35 @@ The receiver:
         - SHOULD store this `channel_announcement`.
 - Once this announced output has been spent OR reorganized out:
     - SHOULD forget a channel after a 72-block delay.
+
+Channel announcement validation:
+- If the output scriptpubkey is neither P2WSH (i.e. 0x00 0x20 [32 bytes]) nor P2TR (i.e. 0x51 0x20 [32 bytes]):
+    - validation fails.
+- If the scriptpubkey is P2TR:
+    - Let `taproot_key` be the x-only key formed by the last 32 bytes of the scriptpubkey.
+- if both `bitcoin_key_1` and `bitcoin_key_2` are present:
+    - If the scriptpubkey is a P2WSH:
+        - if `merkle_root_hash` is present:
+            - validation fails.
+        - if the last 32 bytes of the scriptpubkey do not match the SHA256 of `2 <lesser_bitcoin_key> <greater_bitcoin_key> 2 OP_CHECKMULTISIG` (where lesser and greater are the `bitcoin_key_1` and `bitcoin_key_2` ordered as defined in [BOLT 3](03-transactions.md#funding-transaction-output)):
+            - validation fails
+    - otherwise (P2TR):
+        - Let P_internal = KeyAgg(MuSig2.KeySort(`bitcoin_key_1`, `bitcoin_key_2`))
+        - if `merkle_root_hash` is not present:
+            - if `taproot_key` != P_internal:
+                - validation fails
+        - otherwise:
+            - let `p` = `bytes(P_internal)`
+            - let `t = H("TapTweak", p || merkle_root_hash)` where `H` is the BIP340 tagged hash function defined in [BOLT #12][bolt-12]
+            - if `taproot_key != P_internal + t*G`:
+                - validation fails
+    - Let P_agg = MuSig2.KeyAgg(MuSig2.KeySort(`node_id_1`, `node_id_2`, `bitcoin_key_1`, `bitcoin_key_2`))
+- otherwise (not both bitcoin_key fields):
+    - if either `bitcoin_key_1` or `bitcoin_key_2` are present:
+        - validation fails
+    - Let P_agg = MuSig2.KeyAgg(MuSig2.KeySort(`node_id_1`, `node_id_2`, taproot_key))
+- if `signature` is not a valid signature using P_agg over MsgHash("channel_announcement_2", "signature", message)`:
+    - validation fails
 
 #### TLV Defaults
 
@@ -1133,117 +1164,6 @@ found in the [MuSig2][musig-session-ctx] spec.
 - Let `P = a_n*P_n + a_b*P_b`
 - Let `g = 1` if `has_even_y(Q)`, otherwise `let g = -1 mod n`
 - Fail if `s*G != R_e + e*g*P`
-
-## Verifying the `channel_announcement_2` signature
-
-For all the following cases, it should be verified that the output at the
-provided `short_channel_id` or `outpoint` is an unspent P2WSH or P2TR output.
-
-### The 3-of-3 MuSig2 Scenario
-
-In the case where the funding transaction is a P2TR output and the received
-`channel_announcement_2` message is does not have the optional `bitcoin_key_*`
-fields, the signature of the message should be verified as a 3-of-3 MuSig2
-signature. The keys involved are: `node_id_1`, `node_id_2` and the taproot
-output key (`tr_output_key`) found in the channel's funding output specified by
-the provided `short_channel_id`.
-
-The full list of inputs required:
-- `node_id_1`
-- `node_id_2`
-- `tr_output_key`
-- `msg`: the serialised `channel_announcement_2` tlv stream.
-- `sig`: the 64-byte BIP340 signature found in the `signature` field of the
-  `channel_announcement_2` message. This signature must be parsed into `R` and
-  `s` values as defined in BIP327.
-
-The aggregate key can be calculated as follows:
-
-```
-P_agg = MuSig2.KeyAgg(MuSig2.KeySort(`node_id_1`, `node_id_2`, `tr_output_key`))
-```
-
-The signature can then be verified as follows:
-- Let `pk` = `bytes(P_agg)` where the `bytes` function is defined in BIP340.
-- Let `m` = `MsgHash("channel_announcement_2", "signature", msg)`
-- Use the BIP340 `Verify` function to determine if the signature is valid by
-  passing in `pk`, `m` and `sig`.
-
-### The 4-of-4 MuSig2 Scenario
-
-There are two possibilities here: the channel is a P2WSH channel or a P2TR
-channel.
-
-#### P2WSH Channels
-
-In the case where the funding transaction is a P2WSH output, then the received
-`channel_announcement_2` message MUST have both the optional `bitcoin_key_*`
-fields and the `merkle_root_hash` should not be set. The verifier must then
-ensure that the funding output matches the following P2WSH script:
-
-    `2 <bitcoin_key_1> <bitcoin_key_2> 2 OP_CHECKMULTISIG`
-
-After this has been verified, the signature of the message should be verified.
-This is the same for P2TR channels and is described below.
-
-#### P2TR Channels
-
-In the case where the funding transaction is a P2TR output and the received
-`channel_announcement_2` message has both the optional `bitcoin_key_*` fields,
-the signature of the message should be verified as a 4-of-4 MuSig2 signature.
-The keys involved are: `node_id_1`, `node_id_2`, `bitcoin_key_1` and
-`bitcoin_key_2`. The message may also optionally contain the
-`merkle_root_hash` field in this case.
-
-Before the actual signature verification is done, it should first be asserted
-that the taproot output key found in the funding output is in-fact made up of
-the provided bitcoin keys. This can be done as follows:
-
-First, calculate the aggregate key used as the internal key for the taproot
-output, `P_internal`:
-
-```
-P_internal = KeyAgg(MuSig2.KeySort(`bitcoin_key_1`, `bitcoin_key_2`))
-```
-
-- Let `P_o` be the taproot output key found on-chain in the funding output
-  referred to by the SCID.
-- if the `merkle_root_hash` field is _not_ provided:
-    - Fail the check if `P_internal != P_o`
-- otherwise, if the `merkle_root_hash` is provided:
-    - let `p` = `bytes(P_internal)`
-    - let `t = hash_TapTweak(p || merkle_root_hash)` where `hash_TapTweak` uses
-      the `hash_name(x)` method defined in BIP340.
-    - Fail if `P_o != P_internal + t*G`
-
-If the above check is successful, then it has been shown that the output key
-is constructed from the two provided bitcoin keys.
-
-#### Signature Verification
-
-For both the above cases, the following signature verification applies:
-
-The full list of inputs required:
-- `node_id_1`
-- `node_id_2`
-- `bitcoin_key_1`
-- `bitcoin_key_2`
-- `msg`: the serialised signed range of the `channel_announcement_2` message.
-- `sig`: the 64-byte BIP340 signature found in the `signature` field of the
-  `channel_announcement_2` message. This signature must be parsed into `R` and
-  `s` values as defined in BIP327.
-
-The aggregate key can be calculated as follows:
-
-```
-P_agg = MuSig2.KeyAgg(MuSig2.KeySort(`node_id_1`, `node_id_2`, `bitcoin_key_1`, `bitcoin_key_2`))
-```
-
-The signature can then be verified as follows:
-- Let `pk` = `bytes(P_agg)` where the `bytes` function is defined in BIP340.
-- Let `m` = `MsgHash("channel_announcement_2", "signature", msg)`
-- Use the BIP340 `Verify` function to determine if the signature is valid by
-  passing in `pk`, `m` and `sig`.
 
 ## Signature Message Construction
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -1324,7 +1324,7 @@ _MsgHash:_
       defined in [Pure TLV messages](#pure-tlv-messages).
 
 - Let `tag` = "lightning" || `message_name` || `field_name`
-- return SHA256(SHA256(`tag`) || SHA256(`tag`) || SHA256(`message`))
+- return SHA256(SHA256(`tag`) || SHA256(`tag`) || `message`)
 
 # Appendix B: Test Vectors
 

--- a/bolt-taproot-gossip.md
+++ b/bolt-taproot-gossip.md
@@ -22,6 +22,8 @@ and that use a pure TLV based structure.
         * [`option_gossip_announce_private`](#option_gossip_announce_private)
     * [`open_channel` Extensions](#open_channel-extensions)
     * [`channel_ready` Extensions](#channel_ready-extensions)
+    * [`splice_locked` Extensions](#splice_locked-extensions)
+    * [`channel_reestablish` Extensions](#channel_reestablish-extensions)
     * [`announcement_signatures` Extra requirements](#announcement_signatures-extra-requirements)
     * [The `announcement_signatures_2` Message](#the-announcement_signatures_2-message)
     * [The `channel_announcement_2` Message](#the-channel_announcement_2-message)
@@ -354,9 +356,6 @@ The sender:
       must be set to the public nonce to be used for signing with the node's
       bitcoin key and the `announcement_bitcoin_pubnonce` must be set to the
       public nonce to be used for signing with the node's node ID key.
-    - Upon reconnection, if a fully signed `channel_announcement_2` has not yet
-      been constructed:
-        - SHOULD re-send `channel_ready` with the nonce fields set.
     - Once a `channel_ready` message with the nonce fields has been both sent
       and received:
         - MUST proceed with constructing and sending the
@@ -368,9 +367,6 @@ The sender:
     - If the nonce fields are set, then the node MUST proceed with
       constructing and sending the `announcement_signatures_2` message
       in preparation for advertising the channel using the V2 protocol.
-        - Upon reconnection, if a fully signed `channel_announcement_2` has not
-          yet been constructed:
-        - SHOULD re-send `channel_ready` with the nonce fields set.
     - Once a `channel_ready` message with the nonce fields has been both sent
       and received:
         - MUST proceed with constructing and sending the
@@ -409,6 +405,102 @@ It cannot be a requirement that a node include the nonce fields in the
 `channel_ready` multiple times throughout the life of the channel to update it's
 preferred channel alias, and it does not make sense to require that the nonce
 fields be populated once the channel has already been announced.
+
+Reconnection-time retransmission of `announcement_signatures_2` is handled by
+the `channel_reestablish` extensions defined below; `channel_ready` is not
+re-sent for that purpose.
+
+### `splice_locked` Extensions
+
+After a splice has reached acceptable depth, the channel needs to be
+re-announced under the new funding transaction. This is done with the same
+`announcement_signatures_2` flow used at initial channel open, but parameterised
+by the splice funding transaction rather than the original one. To exchange
+fresh MuSig2 nonces for the new signing session, the same two TLVs defined for
+`channel_ready` are also attached to `splice_locked`:
+
+1. `tlv_stream`: `splice_locked_tlvs`
+2. types:
+    1. type: 0 (`announcement_node_pubnonce`)
+    2. data:
+        * [`66*byte`:`public_nonce`]
+    1. type: 2 (`announcement_bitcoin_pubnonce`)
+    2. data:
+        * [`66*byte`:`public_nonce`]
+
+#### Requirements
+
+The requirements mirror those for the `channel_ready` extensions: if the
+channel was announced (or is to be announced via `option_gossip_announce_private`)
+and `option_gossip_v2` (or `option_gossip_v2_p2wsh` for P2WSH channels) was
+negotiated, the sender MUST include both nonce fields, and the recipient MUST
+either accept both fields or ignore the message.
+
+Both nonces are bound to the `splice_txid` carried by the same `splice_locked`
+message. Once each side has sent and received a `splice_locked` carrying the
+nonces, both MUST proceed with constructing and sending an
+`announcement_signatures_2` message for the new funding transaction.
+
+### `channel_reestablish` Extensions
+
+On reconnection a node may need its peer to retransmit an
+`announcement_signatures_2` message it has not yet received for the current
+funding transaction (initial open or any splice). This extension reuses the
+`my_current_funding_locked` retransmission machinery defined in
+[BOLT #2 §Message Retransmission](02-peer-protocol.md#message-retransmission):
+
+- A new bit is allocated in the `my_current_funding_locked.retransmit_flags`
+  bitfield:
+
+  | Bit Position | Name                       |
+  | ------------ | -------------------------- |
+  | 1            | `announcement_signatures_2`|
+
+  A node sets this bit to ask its peer to retransmit
+  `announcement_signatures_2` for the funding transaction identified by
+  `my_current_funding_locked_txid`.
+
+- A new TLV is added to `channel_reestablish_tlvs` carrying the fresh MuSig2
+  nonces for that signing session:
+
+  1. type: 7 (`announcement_nonces`)
+  2. data:
+      * [`66*byte`:`announcement_node_pubnonce`]
+      * [`66*byte`:`announcement_bitcoin_pubnonce`]
+
+  The nonces apply to the funding transaction identified by
+  `my_current_funding_locked_txid` in the same `channel_reestablish`.
+
+#### Requirements
+
+A node:
+
+- If it sets bit 1 of `my_current_funding_locked.retransmit_flags`:
+    - MUST also include the `announcement_nonces` TLV in the same
+      `channel_reestablish` message, with freshly generated nonces.
+    - MUST NOT reuse nonces from a prior signing session, since MuSig2 nonce
+      reuse is catastrophic.
+- Upon receiving a `channel_reestablish` whose
+  `my_current_funding_locked.retransmit_flags` has bit 1 set:
+    - If `announcement_nonces` is not present:
+        - MUST ignore the bit-1 request.
+        - SHOULD send a `warning`.
+    - Otherwise, once it has also sent its own `channel_reestablish` carrying
+      its own `announcement_nonces` TLV:
+        - MUST retransmit `announcement_signatures_2` for the funding
+          transaction identified by `my_current_funding_locked_txid`, signing
+          the new MuSig2 session under the peer's nonces and its own nonces.
+
+#### Rationale
+
+Re-sending `channel_ready` to retrigger announcement signing was incompatible
+with splicing: `channel_ready` corresponds to the original funding transaction
+only, and overloading it to mean "redo announcement signing for the latest
+funding" conflates the two. `channel_reestablish` already carries the
+"please retransmit the announcement for this funding tx" primitive — extending
+it to also carry the matching MuSig2 nonces is the natural place to put the
+new behaviour, and the same wiring works for initial channel open and every
+subsequent splice.
 
 ### `announcement_signatures` Extra requirements
 
@@ -449,6 +541,9 @@ This message can be sent in two cases:
     2. data:
         * [`partial_signature`:`node_partial_signature`]
         * [`partial_signature`:`bitcoin_partial_signature`]
+    1. type: 6 (`funding_txid`)
+    2. data:
+        * [`sha256`:`funding_txid`]
 
 
 #### Requirements:
@@ -466,6 +561,10 @@ A node:
     - MUST send the `announcement_signatures_2` message once a `channel_ready`
       message containing the announcement nonces has been sent and received AND
       the funding transaction has at least six confirmations.
+    - MUST set `funding_txid` to the txid of the funding transaction for which
+      these partial signatures are being produced. For initial channel open
+      this is the original funding transaction; for a spliced channel this is
+      the txid of the splice transaction last confirmed via `splice_locked`.
     - MUST set `node_partial_signature` and `bitcoin_partial_signature` to the
       two standard MuSig2 partial signatures it produced (one with its
       `node_ID` key, one with its `bitcoin_key`), as described in
@@ -474,31 +573,44 @@ A node:
       m)` where `m` is the canonical signed-range TLV byte sequence of the
       `channel_announcement_2` message (see
       [`MsgHash`](#signature-message-construction)).
+- if a `splice_locked` carrying both announcement nonce fields has been sent
+  and received for a new splice transaction:
+    - MUST send a fresh `announcement_signatures_2` for the new
+      `funding_txid` (the splice transaction's txid).
 - otherwise if the `option_gossip_announce_private` bit has been negotiated:
     - MAY send the `announcement_signatures_2` message at any point during the
       channel's lifetime with the same constraints as defined above.
 - otherwise:
     - MUST NOT send the `announcement_signatures_2` message.
-- upon reconnection (once the above timing requirements have been met):
-    - MUST re-send a `channel_ready` message with the nonce fields set and await
-      a reply.
-    - Then, MUST respond to the first `announcement_signatures_2` message with
-      its own `announcement_signatures_2` message.
-    - if it has NOT received an `announcement_signatures_2` message:
-        - SHOULD retransmit the `channel_ready` and `announcement_signatures_2`
-          messages.
+- upon reconnection, if `announcement_signatures_2` for the current funding
+  transaction has not yet been both sent and received:
+    - MUST set bit 1 of `my_current_funding_locked.retransmit_flags` in its
+      `channel_reestablish` message, with `my_current_funding_locked_txid`
+      equal to the current `funding_txid`, AND include the `announcement_nonces`
+      TLV with freshly-generated nonces (see
+      [`channel_reestablish` Extensions](#channel_reestablish-extensions)).
+    - MUST NOT re-send `channel_ready` (nor `splice_locked`) for the purpose
+      of restarting the announcement-signing flow; the
+      `channel_reestablish` flow above replaces it.
 
 A recipient node:
-- if the `short_channel_id` is NOT correct:
+- if `funding_txid` does NOT match any funding transaction it has
+  established with the sender (initial open or any subsequent splice):
+    - SHOULD send a `warning` and close the connection, or send an
+      `error` and fail the channel.
+- if `short_channel_id` is NOT the canonical scid of the funding output
+  named by `funding_txid`:
     - SHOULD send a `warning` and close the connection, or send an
       `error` and fail the channel.
 - if either `node_partial_signature` or `bitcoin_partial_signature` is NOT
   valid as per [Partial Signature Verification](#partial-signature-verification):
     - MAY send a `warning` and close the connection, or send an
       `error` and fail the channel.
-- if it has sent AND received a valid `announcement_signatures_2` message:
+- if it has sent AND received a valid `announcement_signatures_2` message
+  for the same `funding_txid`:
     - SHOULD queue the `channel_announcement_2` message for its peers.
-- if it has not sent `channel_ready`:
+- if it has not exchanged the announcement nonces for `funding_txid` (via
+  `channel_ready`, `splice_locked` or `channel_reestablish.announcement_nonces`):
     - MAY send a `warning` and close the connection, or send an `error` and fail
       the channel.
 


### PR DESCRIPTION
## Overview

The initial version of the Lightning Network gossip protocol as defined in
BOLT 7 was designed around P2WSH funding transactions. For these
channels, the `channel_announcement` message is used to advertise the 
channel to the rest of the network. Nodes in the network use the content 
of this message to prove that the channel is sufficiently bound to the 
Lightning Network context and that it is owned by the nodes advertising
the channel. This proof and verification protocol is, however, not 
compatible with SegWit V1 (P2TR) outputs and so cannot be used to 
advertise the channels defined in the [Simple Taproot Channel](https://github.com/lightning/bolts/pull/995/commits) proposal. 
This document thus aims to define an updated gossip protocol that will 
allow nodes to both advertise and verify taproot channels. This part of the
 update affects the `announcement_signatures` and 
`channel_announcement` messages.

The opportunity is also taken to rework the `node_announcement` and
`channel_update` messages to take advantage of [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) signatures and
TLV fields. Timestamp fields are also updated to be block heights instead of
Unix timestamps.