### PR TITLE
bolt11: drop requirement to check descriptionhash

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -212,8 +212,6 @@ A reader:
   - if the `9` field contains unknown _even_ bits that are non-zero:
     - MUST fail the payment.
 	- SHOULD indicate the unknown bit to the user.
-  - MUST check that the SHA2 256-bit hash in the `h` field exactly matches the hashed
-  description.
   - if a valid `n` field is provided:
     - MUST use the `n` field to validate the signature instead of performing signature recovery.
   - if there is a valid `s` field:


### PR DESCRIPTION
For some context to the discussion see https://github.com/ElementsProject/lightning/pull/6092.

Today there are hundreds of wallets, node front-ends and services that support Lightning Address, and if LND starts enforcing this bolt11 requirement they will all need to update or break, which is not going to happen, which is why I think this requirement should be dropped from bolt11, regardless if the requirement itself is a good thing or not. Like it or not, but if LND does not enforce this requirement, clients that do enforce it will just brick themselves by enforcing. In the [LNURL Pay Spec](https://github.com/lnurl/luds/blob/luds/06.md), the requirement to check that hash and preimage match falls on the "Wallet" component, which is in most cases not the paying LN node but a client-side application. It is true that having the description is useful for showing historical payments and remembering what they were about, but I think you could claim the node not knowing the description is better for privacy as well in the case of a custodial service.

There are thousands of invoices generated each day which only have a description hash, are passed on from clients to servers (or to other clients) that are maintained by different people, with no way to easily pass the description as well. I believe the best thing to do is to accept that this is a lost battle, drop the requirement from bolt11 and wait for the 2nd coming of Christ (bolt12) to fix this.