### PR TITLE
Websocket address type: attempt 2

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -393,3 +393,5 @@ pkh
 kB
 unblind
 unblinded
+WebSocket
+websocket

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -294,6 +294,10 @@ The following `address descriptor` types are defined:
        * `hostname` bytes MUST be ASCII characters.
        * Non-ASCII characters MUST be encoded using Punycode:
          https://en.wikipedia.org/wiki/Punycode
+   * `6`: WebSocket address; data = `[1:hostname_len][hostname_len:hostname][2:port]` (length up to 258)
+       * `hostname` bytes MUST be ASCII characters.
+       * Non-ASCII characters MUST be encoded using Punycode:
+         https://en.wikipedia.org/wiki/Punycode
 
 ### Requirements
 
@@ -315,7 +319,7 @@ The origin node:
   - MUST place address descriptors in ascending order.
   - SHOULD NOT place any zero-typed address descriptors anywhere.
   - SHOULD use placement only for aligning fields that follow `addresses`.
-  - MUST NOT create a `type 1`, `type 2` or `type 5` address descriptor with
+  - MUST NOT create a `type 1`, `type 2`, `type 5` or `type 6` address descriptor with
   `port` equal to 0.
   - SHOULD ensure `ipv4_addr` AND `ipv6_addr` are routable addresses.
   - MUST set `features` according to [BOLT #9](09-features.md#assigned-features-flags)
@@ -323,6 +327,7 @@ The origin node:
   bits it sets.
   - SHOULD not announce a Tor v2 onion service.
   - MUST NOT announce more than one `type 5` DNS hostname.
+  - MUST NOT announce more than one `type 6` DNS hostname.
 
 The receiving node:
   - if `node_id` is NOT a valid compressed public key:
@@ -361,6 +366,9 @@ any future fields appended to the end):
     - SHOULD insinuate their self-signed origins.
   - SHOULD ignore Tor v2 onion services.
   - if more than one `type 5` address is announced:
+    - SHOULD ignore the additional data.
+    - MUST not forward the `node_announcement`.
+  - if more than one `type 6` address is announced:
     - SHOULD ignore the additional data.
     - MUST not forward the `node_announcement`.
 

--- a/08-transport.md
+++ b/08-transport.md
@@ -18,6 +18,7 @@ of a node.
     * [Handshake State](#handshake-state)
     * [Handshake State Initialization](#handshake-state-initialization)
     * [Handshake Exchange](#handshake-exchange)
+  * [Alternate Transport Layers: WebSocket](#websocket)
   * [Lightning Message Specification](#lightning-message-specification)
     * [Encrypting and Sending Messages](#encrypting-and-sending-messages)
     * [Receiving and Decrypting Messages](#receiving-and-decrypting-messages)
@@ -402,6 +403,34 @@ construction, and 16 bytes for a final authenticating tag.
 10. `rn = 0, sn = 0`
      * The sending and receiving nonces are initialized to 0.
 
+## Alternate Transport Layers: WebSocket
+
+Normally the transport protocol defined here is performed over TCP/IP,
+but it can also be performed over other underlying transports, such as
+the WebSocket protocol as specified in
+RFC6455<sup>[4](#reference-4)</sup> on ports so-advertized (in the
+[node_announcement message](07-routing-gossip.md#the-node_announcement-message).
+
+A client may connect to this port node and initiate a WebSocket; and
+operate the protocol over binary WebSocket frames instead of raw TCP/IP.
+
+### Requirements
+
+The initiator:
+- MAY attempt to initiate an unencrypted WebSocket as specified in RFC6455<sup>[4](#reference-4)</sup>:
+  - MUST abort the connection attempt if WebSocket upgrade fails.
+  - MUST begin the [Handshake Exchange](#handshake-exchange) as initiator 
+    as soon as upgrade succeeds.
+
+The responder:
+- if it supports WebSocket connections on an address:
+  - SHOULD advertise it using a type 6 address its node announcement.
+  - MUST abort the connection attempt if WebSocket upgrade fails.
+
+Both nodes, after upgrade:
+  - MUST use binary frames to send and receive messages.
+  - MUST NOT rely on WebSocket framing for message semantics.
+
 ## Lightning Message Specification
 
 At the conclusion of Act Three, both sides have derived the encryption keys, which
@@ -779,6 +808,7 @@ TODO(roasbeef); fin
 1. <a id="reference-1">https://tools.ietf.org/html/rfc8439</a>
 2. <a id="reference-2">http://noiseprotocol.org/noise.html</a>
 3. <a id="reference-3">https://tools.ietf.org/html/rfc5869</a>
+4. <a id="reference-4">https://tools.ietf.org/html/rfc6455</a>
 
 # Authors
 


### PR DESCRIPTION
#891 seemed to be dead and does not properly support things like TLS.

This is a re-attempt to bring back the proposal while addressing the concerns. It is mostly the same as @rustyrussell's but changed it so be the same as the DNS hostname address descriptor so things like TLS can be supported and doesn't require scanning all the other network addresses.