### PR TITLE
BOLT4: Specify max HTLC nLocktime for expiry_too_far

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -62,6 +62,7 @@ A node:
   * [Returning Errors](#returning-errors)
     * [Failure Messages](#failure-messages)
     * [Receiving Failure Codes](#receiving-failure-codes)
+  * [`max_htlc_cltv` Selection](#max-htlc-cltv-selection)
   * [Onion Messages](#onion-messages)
   * [Test Vector](#test-vector)
     * [Returning Errors](#returning-errors)
@@ -1333,7 +1334,7 @@ A _forwarding node_ MAY, but a _final node_ MUST NOT:
   - if the `cltv_expiry` is unreasonably near the present:
     - report the current channel setting for the outgoing channel.
     - return an `expiry_too_soon` error.
-  - if the `cltv_expiry` is unreasonably far in the future:
+  - if the `cltv_expiry` is more than `max_htlc_cltv` in the future:
     - return an `expiry_too_far` error.
   - if the channel is disabled:
     - report the current channel setting for the outgoing channel.
@@ -1580,6 +1581,10 @@ Onion messages don't explicitly require a channel, but for
 spam-reduction a node may choose to ratelimit such peers, especially
 messages it is asked to forward.
 
+## `max_htlc_cltv` Selection
+
+This `max_htlc_ctlv` value is defined as 2016 blocks, based on historical value
+deployed by Lightning implementations.
 
 # Test Vector
 


### PR DESCRIPTION
Currently BOLT#4 recommends to forwarding node to reject HTLC with `nLocktime` field to far in the future from chain tip height (type 21: `expiry_too_far`). This recommendation is reasonable to avoid liquidity griefing where a HTLC would be send so far in the future (e.g 20 000 blocks from chain tip), than in case of on-chain force-closure of the link, the forwarding node cannot confirm the HTLC-timeout and therefore recover the satoshis locked.

I think this recommendation is implemented by all the main Lightning implementations. For e.g, for LDK will reject HTLC more than 2016 block in the future (`CLTV_FAR_FAR_AWAY`). This comes with few downsides, a) a payer cannot build payment path with more than 14 hops requesting at least a `cltv_expiry_delta` of 144 blocks, such path while onerous in term of off-chain fees could be done for privacy purpose and b) the forwarding nodes are limited in the selection of their own `cltv_expiry_delta`  and as such the level of safety they wish for the HTLC forward (e.g in protection against time-dilation attacks). 

This proposal suggests to adopt a common value between all implementations, dubbed `max_htlc_cltv`. A default value of 4032 blocks (4 weeks) is proposed (though I didn’t check what is selected by LND/CLN/Eclair currently and if it makes sense to adapt in consequence). If adopted, such `max_htlc_cltv` will improve the safety of routing nodes network-wide and allow more advanced rebalancing like #780. 

Beyond, a new option could be introduced [`option_shrek`](https://shrek.fandom.com/wiki/Far_Far_Away) and a corresponding `channel_update` message bit where routing hops are announcing they accept “unsafe” packets beyond 4032 blocks. This level of flexibility can be used by use-cases like multi-hop submarine swaps.

cc https://github.com/lightningdevkit/rust-lightning/pull/2250 