### PR TITLE
bol09: Specify behavior when a node specifies both optional and required features

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -64,10 +64,14 @@ The origin node:
     unless indicated that it must set the odd feature bit instead.
   * MUST NOT set feature bits it does not support.
   * MUST NOT set feature bits in fields not specified by the table above.
+  * MUST NOT set both the optional and mandatory bits.
   * MUST set all transitive feature dependencies.
+  * MUST support:
+    * `var_onion_optin`
 
-The origin node MUST support:
-  * `var_onion_optin`
+The receiving node:
+  * if both the optional and the mandatory feature bits in a pair are set,
+  the feature should be treated as mandatory.
 
 The requirements for receiving specific bits are defined in the linked sections in the table above.
 The requirements for feature bits that are not defined


### PR DESCRIPTION
While reviewing a patch on lnprototest, I encountered a scenario where the BOLT 9 specification needed to provide clear guidance.

As a result, this commit adds specific requirements to determine the appropriate behaviour when a node specifies both optional and required features.

Additionally, if this situation appears to be an
implementation bug, it will be taken care of accordingly.

Reported-by: lnprototest