### PR TITLE
Blinded Paths: clarify outgoing_cltv_value for final hop

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -254,7 +254,7 @@ The creator of `encrypted_recipient_data` (usually, the recipient of payment):
     - `total_fee_proportional_millionths(n+1) = ((total_fee_proportional_millionths(n) + fee_proportional_millionths(n+1)) * 1000000 + total_fee_proportional_millionths(n) * fee_proportional_millionths(n+1) + 1000000 - 1) / 1000000`
   - MUST create the `encrypted_recipient_data` from the `encrypted_data_tlv` as required in [Route Blinding](#route-blinding).
 
-The writer of `tlv_payload`:
+The writer of the TLV `payload`:
 
   - For every node inside a blinded route:
     - MUST include the `encrypted_recipient_data` provided by the recipient

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -262,6 +262,10 @@ The writer of the TLV `payload`:
       - MUST include the `blinding_point` provided by the recipient in `current_blinding_point`
     - If it is the final node:
       - MUST include `amt_to_forward`, `outgoing_cltv_value` and `total_amount_msat`.
+      - The value set for `outgoing_cltv_value`: 
+        - MUST use the current block height as a baseline value. 
+        - if a [random offset](07-routing-gossip.md#recommendations-for-routing) was added to improve privacy:
+          - SHOULD add the offset to the baseline value.
     - MUST NOT include any other tlv field.
   - For every node outside of a blinded route:
     - MUST include `amt_to_forward` and `outgoing_cltv_value`.


### PR DESCRIPTION
This PR replaces #1066, picking this up as discussed in the spec meeting!

Senders making payments to a blinded route know the total `cltv_delta` for the blinded portion of the route, but not the `min_final_cltv_delta` for the final hop. This PR updates the instructions for the sender to set the final hop's `outgoing_cltv_detla` to `current_height + any random offset added`.

See [gist](https://gist.github.com/t-bast/b1371d357a2c5f3e8c09514a62db7079) for additional context.