### PR TITLE
BOLT 1: define what `offered` and `negotiated` mean.

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -255,6 +255,8 @@ Once authentication is complete, the first message reveals the features supporte
 
 [BOLT #9](09-features.md) specifies lists of features. Each feature is generally represented by 2 bits. The least-significant bit is numbered 0, which is _even_, and the next most significant bit is numbered 1, which is _odd_.  For historical reasons, features are divided into global and local feature bitmasks.
 
+A feature is *offered* if a peer set it in the `init` message for the current connection (as either even or odd).  A feature is *negotiated* if either both peers offered it, or the local node offered it as even: it can assume the peer supports it, as it did not disconnect as it would be required to do.
+
 The `features` field MUST be padded to bytes with 0s.
 
 1. type: 16 (`init`)


### PR DESCRIPTION
i.e. it was present in the init feature bits.  We use this in several places, but assume everyone knows what it means.

It's particularly fraught with required features: it's explicitly legitimate to assume these are accepted if the node keeps talking to you after init!