### PR TITLE
Compact representation for node id

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -247,9 +247,8 @@ The following convenience types are also defined:
 * `short_channel_id`: an 8 byte value identifying a channel (see [BOLT #7](07-routing-gossip.md#definition-of-short-channel-id))
 * `sciddir_or_pubkey`: either 9 or 33 bytes referencing or identifying a node, respectively
     * if the first byte is 0 or 1, then an 8-byte `short_channel_id` follows for a total of 9 bytes
-        * 0 for the first byte indicates this refers to `node_id_1` in the `channel_announcement` for `short_channel_id`
-        * 1 for the first byte indicates this refers to `node_id_2` in the `channel_announcement` for `short_channel_id`
-          (see [BOLT #7](07-routing-gossip.md#the-channel_announcement-message)
+        * 0 for the first byte indicates this refers to `node_id_1` in the `channel_announcement` for `short_channel_id` (see [BOLT #7](07-routing-gossip.md#the-channel_announcement-message))
+        * 1 for the first byte indicates this refers to `node_id_2` in the `channel_announcement` for `short_channel_id` (see [BOLT #7](07-routing-gossip.md#the-channel_announcement-message))
     * if the first byte is 2 or 3, then the value is a 33-byte `point`
 * `bigsize`: a variable-length, unsigned integer similar to Bitcoin's CompactSize encoding, but big-endian.  Described in [BigSize](#appendix-a-bigsize-test-vectors).
 

--- a/01-messaging.md
+++ b/01-messaging.md
@@ -245,6 +245,12 @@ The following convenience types are also defined:
 * `signature`: a 64-byte bitcoin Elliptic Curve signature
 * `point`: a 33-byte Elliptic Curve point (compressed encoding as per [SEC 1 standard](http://www.secg.org/sec1-v2.pdf#subsubsection.2.3.3))
 * `short_channel_id`: an 8 byte value identifying a channel (see [BOLT #7](07-routing-gossip.md#definition-of-short-channel-id))
+* `sciddir_or_pubkey`: either 9 or 33 bytes referencing or identifying a node, respectively
+    * if the first byte is 0 or 1, then an 8-byte `short_channel_id` follows for a total of 9 bytes
+        * 0 for the first byte indicates this refers to `node_id_1` in the `channel_announcement` for `short_channel_id`
+        * 1 for the first byte indicates this refers to `node_id_2` in the `channel_announcement` for `short_channel_id`
+          (see [BOLT #7](07-routing-gossip.md#the-channel_announcement-message)
+    * if the first byte is 2 or 3, then the value is a 33-byte `point`
 * `bigsize`: a variable-length, unsigned integer similar to Bitcoin's CompactSize encoding, but big-endian.  Described in [BigSize](#appendix-a-bigsize-test-vectors).
 
 ## Setup Messages

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -468,7 +468,7 @@ may contain the following TLV fields:
         * [`short_channel_id`:`short_channel_id`]
     1. type: 4 (`next_node_id`)
     2. data:
-        * [`point`:`node_id`]
+        * [`sciddir_or_pubkey`:`node_id`]
     1. type: 6 (`path_id`)
     2. data:
         * [`...*byte`:`data`]
@@ -1476,7 +1476,7 @@ even, of course!).
 
 1. subtype: `blinded_path`
 2. data:
-   * [`point`:`first_node_id`]
+   * [`sciddir_or_pubkey`:`first_node_id`]
    * [`point`:`blinding`]
    * [`byte`:`num_hops`]
    * [`num_hops*onionmsg_hop`:`path`]


### PR DESCRIPTION
To save space in offers (#798) that need to fit on a QR code, we can identify public nodes by one of their public channel, using only 9 bytes instead of 33.
This was suggested by @jkczyz in https://github.com/lightning/bolts/pull/798/commits/3db064e4cb943885ff5557181ae655d03ac8ce79, I'm adding using it in the `next_node_id` field inside blinded routes.
Using it in the `next_node_id` field is needed for nodes that rely on trampoline and do not know the network graph. When such a node is given a compact blinded route, it can't find the corresponding public key for the introduction node id and needs to rely on its trampoline provider to do it.