### PR TITLE
Fix incorrect hex value for Signet port in BOLT #1

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -9,7 +9,7 @@ The default TCP port depends on the network used. The most common networks are:
 
 - Bitcoin mainnet with port number 9735 or the corresponding hexadecimal `0x2607`;
 - Bitcoin testnet with port number 19735 (`0x4D17`);
-- Bitcoin signet with port number 39735 (`0xF87`).
+- Bitcoin signet with port number 39735 (`0x9B37`).
 
 The Unicode code point for LIGHTNING <sup>[1](#reference-1)</sup>, and the port convention try to follow the Bitcoin Core convention.
 


### PR DESCRIPTION
The documentation incorrectly listed the hexadecimal value of the Signet port as 0xF87 when it should be 0x9B77. This commit updates the port to the correct hexadecimal representation.