### PR TITLE
BOLT 4: It's Check Lock Time Verify not Check Time Lock Verify.

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1583,7 +1583,7 @@ messages it is asked to forward.
 
 ## `max_htlc_cltv` Selection
 
-This `max_htlc_ctlv` value is defined as 2016 blocks, based on historical value
+This `max_htlc_cltv` value is defined as 2016 blocks, based on historical value
 deployed by Lightning implementations.
 
 # Test Vector


### PR DESCRIPTION
I always get this wrong too, so CLN actually has a source check for this, and it triggered when importing the latest spec!