### PR TITLE
Advertise liquidity ads rates

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -285,7 +285,7 @@ The `features` field MUST be padded to bytes with 0s.
         * [`...*byte`:`data`]
     1. type: 5 (`option_will_fund`)
     2. data:
-        * [`...*16*byte`:`lease_rates`]
+        * [`...*24*byte`:`lease_rates`]
 
 The optional `networks` indicates the chains the node is interested in.
 The optional `remote_addr` can be used to circumvent NAT issues.

--- a/01-messaging.md
+++ b/01-messaging.md
@@ -283,6 +283,9 @@ The `features` field MUST be padded to bytes with 0s.
     1. type: 3 (`remote_addr`)
     2. data:
         * [`...*byte`:`data`]
+    1. type: 5 (`option_will_fund`)
+    2. data:
+        * [`...*16*byte`:`lease_rates`]
 
 The optional `networks` indicates the chains the node is interested in.
 The optional `remote_addr` can be used to circumvent NAT issues.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -276,11 +276,13 @@ nodes not associated with an already known channel are ignored.
 2. types:
    1. type: 1 (`option_will_fund`)
    2. data:
-       * [`...*16*byte`:`lease_rates`]
+       * [`...*24*byte`:`lease_rates`]
 
 1. subtype: `lease_rate`
 2. data:
    * [`u16`:`lease_duration`]
+   * [`u32`:`min_lease_amount_sat`]
+   * [`u32`:`max_lease_amount_sat`]
    * [`u16`:`funding_weight`]
    * [`u16`:`lease_fee_basis`]
    * [`u32`:`lease_fee_base_sat`]
@@ -360,7 +362,11 @@ The origin node:
   - If it includes `option_will_fund`:
     - MUST set `lease_duration` to the number of blocks during which the lease
       will be active.
+    - MUST set `min_lease_amount_sat` and `max_lease_amount_sat` to the minimum
+      and maximum amount it will contribute at this rate.
     - SHOULD include one `lease_rate` for each lease duration it supports.
+    - SHOULD include one `lease_rate` for each amount range it supports.
+    - MUST NOT include more than ten `lease_rate`s.
     - MUST set `lease_fee_base_sat` to the base fee (in satoshi) it will charge.
     - MUST set `lease_fee_basis` to the amount it will charge per contributed
       satoshi (in basis points, ie 1/10_000).
@@ -411,6 +417,8 @@ any future fields appended to the end):
   - SHOULD ignore Tor v2 onion services.
   - if more than one `type 5` address is announced:
     - SHOULD ignore the additional data.
+    - MUST not forward the `node_announcement`.
+  - if more than ten `lease_rate`s are included:
     - MUST not forward the `node_announcement`.
 
 ### Rationale


### PR DESCRIPTION
Add the ability to advertise rates at which nodes wish to sell their liquidity. Buyers can then connect to sellers and request liquidity, at one of the advertised rates.

This can be used when creating a dual-funded channel, where both participants contribute to the funding transaction, and one of them is paid for (some of) their contribution. This can also be used to splice additional liquidity into existing channels, when splicing is supported.

We don't add any constraints to the commitment transaction. The lease duration isn't protected by script opcodes, which means that the seller could immediately close the channel, or splice funds out. It is up to the buyer to then blacklist that seller.

This is a subset of #878 and mostly matches what @niftynei proposed there, with some changes that were discussed during the review process and over threads on the mailing list (such as https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-December/004227.html). The goal of this PR is to be a first step that can be integrated before #878 and allows nodes to buy/sell liquidity without restrictions on the seller side, relying on incentives rather than scripts inside the commitment transactions. This will let us observe what behaviors emerge and the market dynamics. If we feel that adding restrictions on the seller side by modifying the commitment transactions can be useful (as proposed in #878), we can easily add it on top of this change using a dedicated feature bit. It would still allow unrestricted liquidity leases, by simply using a `lease_duration` of `0`. This provides an easy path for a more complex change, without sacrificing simplicity in the short term.