### PR TITLE
gossip: 12-blocks delay channel closed follow-up

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -983,7 +983,7 @@ The origin node:
 A node:
   - SHOULD monitor the funding transactions in the blockchain, to identify
   channels that are being closed.
-  - if the funding output of a channel is being spent:
+  - if the funding output of a channel is spent and received 12 block confirmations:
     - SHOULD be removed from the local network view AND be considered closed.
   - if the announced node no longer has any associated open channels:
     - MAY prune nodes added through `node_announcement` messages from their


### PR DESCRIPTION
We introduced a 12-blocks delay for channel closing in #1004, but we didn't update the requirement in the section about pruning. This is just a follow-up on that PR.

@niftynei @TheBlueMatt @rustyrussell 
