### PR TITLE
bolt4+proposals: fix `max_cltv_expiry` calculation

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -246,9 +246,11 @@ The creator of `encrypted_recipient_data` (usually, the recipient of payment):
   - MUST create `encrypted_data_tlv` for each node in the blinded route (including itself).
   - MUST include `encrypted_data_tlv.short_channel_id` and `encrypted_data_tlv.payment_relay` for each non-final node.
   - MUST NOT include `encrypted_data_tlv.next_node_id`.
-  - MUST set `encrypted_data_tlv.payment_constraints` for each non-final node:
+  - MUST set `encrypted_data_tlv.payment_constraints` for each non-final node and MAY set it for the final node:
     - `max_cltv_expiry` to the largest block height at which the route is allowed to be used, starting
-    from the final node and adding `encrypted_data_tlv.payment_relay.cltv_expiry_delta` at each hop.
+       from the final node's chosen `max_cltv_expiry` height at which the route should expire, adding 
+       the final node's `min_final_cltv_expiry_delta` and then adding 
+       `encrypted_data_tlv.payment_relay.cltv_expiry_delta` at each hop.
     - `htlc_minimum_msat` to the largest minimum HTLC value the nodes will allow.
   - If it sets `encrypted_data_tlv.allowed_features`:
     - MUST set it to an empty array.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -254,9 +254,10 @@ The creator of `encrypted_recipient_data` (usually, the recipient of payment):
     - `htlc_minimum_msat` to the largest minimum HTLC value the nodes will allow.
   - If it sets `encrypted_data_tlv.allowed_features`:
     - MUST set it to an empty array.
-  - MUST compute the total fees and cltv delta of the route as follows and communicate them to the sender:
+  - MUST compute the total fees and CLTV delta of the route as follows and communicate them to the sender:
     - `total_fee_base_msat(n+1) = (fee_base_msat(n+1) * 1000000 + total_fee_base_msat(n) * (1000000 + fee_proportional_millionths(n+1)) + 1000000 - 1) / 1000000`
     - `total_fee_proportional_millionths(n+1) = ((total_fee_proportional_millionths(n) + fee_proportional_millionths(n+1)) * 1000000 + total_fee_proportional_millionths(n) * fee_proportional_millionths(n+1) + 1000000 - 1) / 1000000`
+    - `total_cltv_delta = cltv_delta(0) + cltv_delta(1) + ... + cltv_delta(n) + min_final_cltv_expiry_delta`
   - MUST create the `encrypted_recipient_data` from the `encrypted_data_tlv` as required in [Route Blinding](#route-blinding).
 
 The writer of the TLV `payload`:

--- a/proposals/route-blinding.md
+++ b/proposals/route-blinding.md
@@ -261,7 +261,9 @@ total `cltv_expiry_delta`. This yields the following values:
 * `route_cltv_expiry_delta`: 300
 
 Let's assume the current block height is 1000. Alice wants the route to be used in the next 200
-blocks, so she sets `max_cltv_expiry = 1200` and adds `cltv_expiry_delta` for each hop. Alice then
+blocks, meaning that the `max_cltv_expiry` she will communicate to the payer will be 1200. She 
+also wants a `min_final_cltv_expiry_delta` of 12 though and so in the encrypted payload to herself, 
+she sets `max_cltv_expiry = 1212` and adds `cltv_expiry_delta` for each hop after that. Alice then
 transmits the following information to the sender (most likely via an invoice):
 
 * Blinded route: `[N(carol), B(bob), B(alice)]`
@@ -276,7 +278,7 @@ transmits the following information to the sender (most likely via an invoice):
 * Encrypted data for blinded nodes:
   * `encrypted_payload(alice)`:
     * `path_id`: `payment_preimage`
-    * `max_cltv_expiry`: 1200
+    * `max_cltv_expiry`: 1212
   * `encrypted_payload(bob)`:
     * `outgoing_channel_id`: `scid_bob_alice`
     * `fee_base_msat`: 100


### PR DESCRIPTION
- This PR adds some clarification in BOLT 4 around how to calculate the `max_ctlv_expiry` that is added to the `payment_constraints` field for
hops in a blinded path. 
- It also adds a formula for calculating the total 
blinded path cltv delta so that it is clear that this should include the `min_final_cltv_expiry_delta`. 
- Finally, the route blinding payments example in the proposals doc is
  fixed so that the correct `max_cltv_expiry` is included in the final 
  hop's payload. 

Fixes https://github.com/lightning/bolts/issues/1174


The one other thing from #1174 that I didnt cover here was re the shadow route suggestions: for blinded paths. See comment [here](https://github.com/lightning/bolts/issues/1174#issuecomment-2189795809) for more details. If it is agreed that it no longer makes sense for the sender to be responsible for adding the shadow route buffer, then maybe we should add that to the spec