### PR TITLE
Clarify onionmessage decryption

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1975,9 +1975,9 @@ is destined, is described in [BOLT #4](04-onion-routing.md).
 
 1. `tlv_stream`: `update_add_htlc_tlvs`
 2. types:
-    1. type: 0 (`blinding_point`)
+    1. type: 0 (`blinded_path`)
     2. data:
-        * [`point`:`blinding`]
+        * [`point`:`path_key`]
 
 #### Requirements
 
@@ -2015,7 +2015,7 @@ A sending node:
     - MUST set `id` to 0.
   - MUST increase the value of `id` by 1 for each successive offer.
   - if it is relaying a payment inside a blinded route:
-    - MUST set `blinding_point` (see [Route Blinding](04-onion-routing.md#route-blinding))
+    - MUST set `path_key` (see [Route Blinding](04-onion-routing.md#route-blinding))
 
 `id` MUST NOT be reset to 0 after the update is complete (i.e. after `revoke_and_ack` has
 been received). It MUST continue incrementing instead.
@@ -2040,7 +2040,7 @@ A receiving node:
   - if other `id` violations occur:
     - MAY send a `warning` and close the connection, or send an
       `error` and fail the channel.
-  - MUST decrypt `onion_routing_packet` as specified in [Onion Decryption](04-onion-routing.md#onion-decryption) using `payment_hash` as `associated_data` (and `blinding` if specified).
+  - MUST decrypt `onion_routing_packet` as specified in [Onion Decryption](04-onion-routing.md#onion-decryption) using `payment_hash` as `associated_data` (and `path_key` if specified).
   - If that fails, or the payload is not a valid `payload` TLV:
     - MUST report the failure to the origin node as described in [Returning Errors](04-onion-routing.md#returning-errors)
   - MUST follow the requirements for processing the payload under [Failure Messages](04-onion-routing.md#failure-messages)
@@ -2127,14 +2127,14 @@ A node:
     - MUST NOT send an `update_fulfill_htlc`, `update_fail_htlc`, or
 `update_fail_malformed_htlc`.
   - When failing an incoming HTLC:
-    - If `current_blinding_point` is set in the onion payload and it is not the
+    - If `current_path_key` is set in the onion payload and it is not the
       final node:
       - MUST send an `update_fail_htlc` error using the `invalid_onion_blinding`
         failure code for any local or downstream errors.
       - SHOULD use the `sha256_of_onion` of the onion it received.
       - MAY use an all zero `sha256_of_onion`.
       - SHOULD add a random delay before sending `update_fail_htlc`.
-    - If `blinding_point` is set in the incoming `update_add_htlc`:
+    - If `path_key` is set in the incoming `update_add_htlc`:
       - MUST send an `update_fail_malformed_htlc` error using the
         `invalid_onion_blinding` failure code for any local or downstream errors.
       - SHOULD use the `sha256_of_onion` of the onion it received.

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -2040,8 +2040,10 @@ A receiving node:
   - if other `id` violations occur:
     - MAY send a `warning` and close the connection, or send an
       `error` and fail the channel.
-  - if `blinding_point` is provided:
-    - MUST use the corresponding blinded private key to decrypt the `onion_routing_packet` (see [Route Blinding](04-onion-routing.md#route-blinding))
+  - MUST decrypt `onion_routing_packet` as specified in [Onion Decryption](04-onion-routing.md#onion-decryption) using `payment_hash` as `associated_data` (and `blinding` if specified).
+  - If that fails, or the payload is not a valid `payload` TLV:
+    - MUST report the failure to the origin node as described in [Returning Errors](04-onion-routing.md#returning-errors)
+  - MUST follow the requirements for processing the payload under [Failure Messages](04-onion-routing.md#failure-messages)
 
 The `onion_routing_packet` contains an obfuscated list of hops and instructions for each hop along the path.
 It commits to the HTLC by setting the `payment_hash` as associated data, i.e. includes the `payment_hash` in the computation of HMACs.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -294,13 +294,11 @@ The reader:
   - If `encrypted_recipient_data` is present:
     - If `blinding_point` is set in the incoming `update_add_htlc`:
       - MUST return an error if `current_blinding_point` is present.
-      - MUST use that `blinding_point` as the blinding point for decryption.
     - Otherwise:
       - MUST return an error if `current_blinding_point` is not present.
-      - MUST use that `current_blinding_point` as the blinding point for decryption.
+      - MUST use that `current_blinding_point` as `E_i` to derive the following blinding point.
       - SHOULD add a random delay before returning errors.
-    - MUST return an error if `encrypted_recipient_data` does not decrypt using the
-      blinding point as described in [Route Blinding](#route-blinding).
+    - MUST return an error if `encrypted_recipient_data` does not decrypt to a valid `encrypted_data_tlv` as described in [Route Blinding](#route-blinding).
     - If `payment_constraints` is present:
       - MUST return an error if:
         - the expiry is greater than `encrypted_recipient_data.payment_constraints.max_cltv_expiry`.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -463,27 +463,32 @@ A blinded path consists of:
    to tell them the next hop.
 
 For example, Dave wants Alice to reach him via public node Bob then
-Carol.  He creates and encrypts three `encrypted_data_tlv`s:
+Carol.  He creates a chain of public "blinding" keys for Bob, Carol
+and finally himself, so he can share a secret with each of them.  These
+keys are a simple chain, so each node can derive the next without
+having to be told explicitly.
+
+From these shared secrets, Dave creates and encrypts three `encrypted_data_tlv`s:
 1. blob_bob: For Bob to tell him to forward to Carol
 2. blob_carol: For Carol to tell her to forward to him
 3. blob_dave: For himself to indicate the path was used, and any metadata he wants.
 
-To mask the node ids, he derives three blinding factors, which turn
-Bob into Bob', Carol into Carol' and Dave into Dave'.  These are a simple
-chain, so Bob can derive Carols without having to be told explicitly.
+To mask the node ids, he also derives three blinding factors from the
+shared secrets, which turn Bob into Bob', Carol into Carol' and Dave
+into Dave'.
 
 So this is the `blinded_path` he hands to Alice.
 
 1. `first_node_id`: Bob
-2. `blinding`: to turn Bob into Bob'
+2. `blinding`: the first blinding key
 3. `path`: [Bob', bob_blob], [Carol', carol_blob], [Dave', dave_blob]
 
 Alice encrypts an onion to Bob', Carol', Dave' and gives it to Bob
-with the first blinding factor `blinding`.
+with the first blinding key `blinding`.
 
-Bob uses the blinding and his private key to decrypt the first layer
-of the onion (created by Alice), and uses his normal private key to
-decrypt "bob_blob" (created by Dave).  The blob decrypts into a
+Bob uses the first blinding key to derive the shared secret which
+gives him both the tweak to decrypt the onion so he can decrypt it
+(created by Alice for Bob' instead of Bob) and also to decrypt the
 `encrypted_data_tlv` which indicates where the onion is to be
 forwarded (i.e. Carol).  Bob derives the next `blinding` and sends it
 an the onion to Carol.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -50,7 +50,8 @@ A node:
   * [Packet Structure](#packet-structure)
     * [Payload Format](#payload-format)
     * [Basic Multi-Part Payments](#basic-multi-part-payments)
-    * [Route Blinding](#route-blinding)
+  * [Route Blinding](#route-blinding)
+    * [Inside encrypted_recipient_data: encrypted_data_tlv](Inside-encrypted_recipient_data-encrypted_data_tlv)
   * [Accepting and Forwarding a Payment](#accepting-and-forwarding-a-payment)
     * [Payload for the Last Node](#payload-for-the-last-node)
     * [Non-strict Forwarding](#non-strict-forwarding)
@@ -434,12 +435,12 @@ otherwise meets the amount criterion (eg. some other failure, or
 invoice timeout), however if it were to fulfill only some of them,
 intermediary nodes could simply claim the remaining ones.
 
-### Route Blinding
+## Route Blinding
 
-Nodes receiving onion packets may hide their identity from senders by
-providing a `blinded_path`.  To do this the recipient needs to hide both
-the real node ids, and the instructions to those nodes on where to forward
-the onion.
+Nodes receiving onion packets (either onion messages, or payments) may
+hide their identity from senders by providing a `blinded_path`.  To do
+this the recipient needs to hide both the real node ids, and the
+instructions to those nodes on where to forward the onion.
 
 1. subtype: `blinded_path`
 2. data:
@@ -487,16 +488,90 @@ decrypt "bob_blob" (created by Dave).  The blob decrypts into a
 forwarded (i.e. Carol).  Bob derives the next `blinding` and sends it
 an the onion to Carol.
 
+### Requirements
+
+Note that the creator of the blinded path (i.e. the recipient) is creating it for the sender to use to create an onion, and for the intermediate nodes to read the instructions, hence there are two reader sections here.
+
+The writer of `blinded_path`:
+
+- MUST create a viable path to itself ($`N_r`$) i.e. $`N_0 \rightarrow N_1 \rightarrow ... \rightarrow N_r`$.
+- MUST set `first_node_id` to $`N_0`$
+- MUST create a series of ECDH shares secrets for each node in the route using the following algorithm:
+  - $`e_0 /leftarrow {0;1}^256`$ ($`e_0`$ SHOULD be obtained via CSPRG)
+  - $`E_0 = e_0 \cdot G`$
+  - For every node in the route:
+    - let $`N_i = k_i * G`$ be the `node_id` ($`k_i`$ is $`N_i`$'s private key)
+    - $`ss_i = SHA256(e_i * N_i) = SHA256(k_i * E_i)$` (ECDH shared secret known only by $`N_r`$ and $`N_i`$)
+    - $`e_{i+1} = SHA256(E_i || ss_i) * e_i`$ (blinding ephemeral private key, only known by $`N_r`$)
+    - $`E_{i+1} = SHA256(E_i || ss_i) * E_i`$ (NB: $`N_i`$ MUST NOT learn $`e_i`$)
+- MUST set `blinding` to $`E_0`$
+- MUST create a series of blinded node IDs $`B_i`$ for each node using the following algorithm:
+  - $`B_i = HMAC256(\text{"blinded\_node\_id"}, ss_i) * N_i`$ (blinded `node_id` for $`N_i`$, private key known only by $`N_i`$)
+  - MUST set `blinded_node_id` for each `onionmsg_hop` in `path` to $`B_i`$
+- MAY store private data in `encrypted_data_tlv[r].path_id` to verify that the route is used in the right context and was created by them
+- SHOULD add padding data to ensure all `encrypted_data_tlv[i]` have the same length
+- MUST set `encrypted_recipient_data` for each `onionmsg_hop` in `path` by encrypting each `encrypted_data_tlv[i]` with ChaCha20-Poly1305 using an all-zero nonce key:
+  - $`rho_i = HMAC256(\text{"rho"}, ss_i)`$ (key used to encrypt the payload for $`N_i`$ by $`N_r`$)
+- MAY replace $`E_{i+1}`$ with a different value, but if it does:
+  - MUST set `encrypted_data_tlv[i].next_blinding_override` to `$E_{i+1}$`
+
+The reader of the `blinded_path`:
+- MUST create its own onion to reach the `first_node_id` of the blinded path
+- For the first entry in `path`:
+  - if it is sending a payment:
+    - MAY encrypt the first blinded path onion to `first_node_id` and include `blinding` as `current_blinding_point`
+  - if it does not do that:
+    - MUST encrypt the first blinded path onion to the first `blinded_node_id`.
+	- MUST set `next_blinding_override` in the prior onion payload to `blinding`.
+  - MUST include the first `path` `encrypted_recipient_data` in each onion payload within the blinded path.
+- For each successive entry in `path`:
+  - MUST encrypt the onion to the corresponding `blinded_node_id`.
+  - MUST include the corresponing `path` `encrypted_recipient_data` in the onion payload
+
+The reader of the `encrypted_recipient_data`:
+
+- MUST compute:
+  - $`ss_i = SHA256(k_i * E_i)`$ (standard ECDH)
+  - $`rho_i = HMAC256(\text{"rho"}, ss_i)`$
+- MUST decrypt the `encrypted_data` field using $`rho_i`$ as a key using ChaCha20-Poly1305 and an all-zero nonce key.
+- If the `encrypted_data` field is missing or cannot be decrypted:
+  - MUST return an error
+- If `encrypted_data` contains a `next_blinding_override`:
+  - MUST use it as the next blinding point.
+- Otherwise:
+  - MUST use $`E_{i+1} = SHA256(E_i || ss_i) * E_i`$ as the next blinding point
+- MUST forward the onion and include the next blinding point in the lightning
+  message for the next node
+- If it is the final recipient:
+  - MUST ignore the message if the `path_id` does not match the blinded route it
+    created for this purpose
+
+### Rationale
+
 Note that there are two ways for the sender to reach the introduction
 point: one is to create a normal (unblinded) payment, and place the
 initial blinding point in `current_blinding_point` along with the
 `encrypted_data` in the onion payload for the introduction point to
-start the blinded path. The second way is to create a blinded path to
+start the blinded path. The second way (which is the only way for
+onion messages) is to create a blinded path to
 the introduction point, set `next_blinding_override` inside the
 `encrypted_data_tlv` on the hop prior to the introduction point to the
 initial blinding point, and have it sent to the introduction node.
 
-The `encrypted_data` is a TLV stream, encrypted for a given blinded node, that
+The final recipient must verify that the blinded route is used in the right
+context (e.g. for a specific payment) and was created by them. Otherwise a
+malicious sender could create different blinded routes to all the nodes that
+they suspect could be the real recipient and try them until one accepts the
+message. The recipient can protect against that by storing `E_r` and the
+context (e.g. a `payment_hash`), and verifying that they match when receiving
+the onion. Otherwise, to avoid additional storage cost, it can put some private
+context information in the `path_id` field (e.g. the `payment_preimage`) and
+verify that when receiving the onion. Note that it's important to use private
+information in that case, that senders cannot have access to.
+
+### Inside `encrypted_recipient_data`: `encrypted_data_tlv`
+
+The `encrypted_recipient_data` is an encrypted TLV for a given blinded node, that
 may contain the following TLV fields:
 
 1. `tlv_stream`: `encrypted_data_tlv`
@@ -531,96 +606,9 @@ may contain the following TLV fields:
 
 #### Requirements
 
-A recipient $`N_r`$ creating a blinded route $`N_0 \rightarrow N_1 \rightarrow ... \rightarrow N_r`$ to itself:
-
-- MUST create a series of ECDH shares secrets for each node in the route using the following algorithm:
-  - $`e_0 /leftarrow {0;1}^256`$ ($`e_0`$ SHOULD be obtained via CSPRG)
-  - $`E_0 = e_0 \cdot G`$
-  - For every node in the route:
-    - let $`N_i = k_i * G`$ be the `node_id` ($`k_i`$ is $`N_i`$'s private key)
-    - $`ss_i = SHA256(e_i * N_i) = SHA256(k_i * E_i)$` (ECDH shared secret known only by $`N_r`$ and $`N_i`$)
-    - $`e_{i+1} = SHA256(E_i || ss_i) * e_i`$ (blinding ephemeral private key, only known by $`N_r`$)
-    - $`E_{i+1} = SHA256(E_i || ss_i) * E_i`$ (NB: $`N_i`$ MUST NOT learn $`e_i`$)
-- MUST create a blinded node ID $`B_i`$ for each node using the following algorithm:
-  - $`B_i = HMAC256(\text{"blinded\_node\_id"}, ss_i) * N_i`$ (blinded `node_id` for $`N_i`$, private key known only by $`N_i`$)
-- MUST produce `encrypted_recipient_data[i]` by encrypting each `encrypted_data_tlv[i]` with ChaCha20-Poly1305 using an all-zero nonce key:
-  - $`rho_i = HMAC256(\text{"rho"}, ss_i)`$ (key used to encrypt the payload for $`N_i`$ by $`N_r`$)
-- MAY replace $`E_{i+1}`$ with a different value, but if it does:
-  - MUST set `encrypted_data_tlv[i].next_blinding_override` to `$E_{i+1}$`
-- MAY store private data in `encrypted_data_tlv[r].path_id` to verify that the route is used in the right context and was created by them
-- SHOULD add padding data to ensure all `encrypted_data_tlv[i]` have the same length
-- MUST communicate the blinded node IDs $`B_i`$ and `encrypted_recipient_data[i]` to the sender
-- MUST communicate the real node ID of the introduction point $`N_0`$ to the sender
-- MUST communicate the first blinding ephemeral key $`E_0`$ to the sender
-
-A reader:
-
-- If it receives `blinding_point` ($`E_i`$) from the prior peer:
-  - MUST use $`b_i`$ instead of its private key $`k_i`$ to decrypt the onion.
-    Note that the node may instead tweak the onion ephemeral key with
-    $`HMAC256(\text{"blinded\_node\_id}", ss_i)`$ which achieves the same result.
-- Otherwise:
-  - MUST use $`k_i`$ to decrypt the onion, to extract `current_blinding_point` ($`E_i`$).
-- MUST compute:
-  - $`ss_i = SHA256(k_i * E_i)`$ (standard ECDH)
-  - $`b_i = HMAC256(\text{"blinded\_node\_id"}, ss_i) * k_i`$
-  - $`rho_i = HMAC256(\text{"rho"}, ss_i)`$
-  - $`E_{i+1} = SHA256(E_i || ss_i) * E_i`$
-- MUST decrypt the `encrypted_data` field using $`rho_i`$ and use the
-  decrypted fields to locate the next node
-- If the `encrypted_data` field is missing or cannot be decrypted:
-  - MUST return an error
-- If `encrypted_data` contains a `next_blinding_override`:
-  - MUST use it as the next blinding point instead of $`E_{i+1}`$
-- Otherwise:
-  - MUST use $`E_{i+1}`$ as the next blinding point
-- MUST forward the onion and include the next blinding point in the lightning
-  message for the next node
-
-The final recipient:
-
-- MUST compute:
-  - $`ss_r = SHA256(k_r * E_r)`$ (standard ECDH)
-  - $`b_r = HMAC256(\text{"blinded\_node\_id"}, ss_r) * k_r`$
-  - $`rho_r = HMAC256(\text{"rho"}, ss_r)`$
-- MUST decrypt the `encrypted_data` field using $`rho_r`$
-- If the `encrypted_data` field is missing or cannot be decrypted:
-  - MUST return an error
-- MUST ignore the message if the `path_id` does not match the blinded route it
-  created
+The requirements are detailed separately for payments ([Payload Format](#payload-format) and [Onion Messages](#onion-messages).
 
 #### Rationale
-
-Route blinding is a lightweight technique to provide recipient anonymity.
-It's more flexible than rendezvous routing because it simply replaces the public
-keys of the nodes in the route with random public keys while letting senders
-choose what data they put in the onion for each hop. Blinded routes are also
-reusable in some cases (e.g. onion messages).
-
-Each node in the blinded route needs to receive `E_i` to be able to decrypt
-the onion and the `encrypted_data` payload. Protocols that use route blinding
-must specify how this value is propagated between nodes.
-
-When concatenating two blinded routes generated by different nodes, the
-last node of the first route needs to know the first `blinding_point` of the
-second route: the `next_blinding_override` field must be used to transmit this
-information.
-
-The final recipient must verify that the blinded route is used in the right
-context (e.g. for a specific payment) and was created by them. Otherwise a
-malicious sender could create different blinded routes to all the nodes that
-they suspect could be the real recipient and try them until one accepts the
-message. The recipient can protect against that by storing `E_r` and the
-context (e.g. a `payment_hash`), and verifying that they match when receiving
-the onion. Otherwise, to avoid additional storage cost, it can put some private
-context information in the `path_id` field (e.g. the `payment_preimage`) and
-verify that when receiving the onion. Note that it's important to use private
-information in that case, that senders cannot have access to.
-
-Whenever the introduction point receives a failure from the blinded route, it
-should add a random delay before forwarding the error. Failures are likely to
-be probing attempts and message timing may help the attacker infer its distance
-to the final recipient.
 
 The `padding` field can be used to ensure that all `encrypted_data` have the
 same length. It's particularly useful when adding dummy hops at the end of a

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1115,10 +1115,6 @@ lightning implementations serialized this without the `0x0102` message type.
 
 The following `failure_code`s are defined:
 
-1. type: PERM|1 (`invalid_realm`)
-
-The `realm` byte was not understood by the processing node.
-
 1. type: NODE|2 (`temporary_node_failure`)
 
 General temporary failure of the processing node.
@@ -1305,8 +1301,6 @@ An _erring node_:
       - SHOULD select the first error it encounters from the list above.
 
 An _erring node_ MAY:
-  - if the `realm` byte is unknown:
-    - return an `invalid_realm` error.
   - if the per-hop payload in the onion is invalid (e.g. it is not a valid tlv stream)
   or is missing required information (e.g. the amount was not specified):
     - return an `invalid_onion_payload` error.


### PR DESCRIPTION
I recently re-implemented this to get our code production ready, and I found the spec unclear and even misleading.  This series seeks to rework it to be clearer and more coherent.

Most pointedly, it's now clear that blinding applies to the onion, not the internal encrypted blob: the spec was confused about this at various points.  The onion decoding is now specified exactly, and is general.  The old references to "realms" (from legacy onions) is removed.