### PR TITLE
Add MODERATION-GUIDELINES

### DIFF
--- a/MODERATION-GUIDELINES.md
+++ b/MODERATION-GUIDELINES.md
@@ -1,0 +1,67 @@
+# Moderation Guidelines
+
+Comments on Lightning github repository issues, pull requests and Lightning IRC channels will be **actively** moderated, on the understanding that it is easier to rephrase deleted comments to be constructive and respectful than to replace long term contributors who are burnt out from a discussion culture that is unnecessarily contentious and overbearing.
+
+On the internet, different discussion forums will have different cultural norms, but within Lightning protocol specification projects, moderators will seek to uphold the following norms:
+
+- Comments will be on-topic.
+- Comments will be about ideas, not people.
+- Comments may offer pointed criticism, if it is criticism about specific technical ideas or decisions, not general criticism, or criticism of individuals or groups. Even the smartest people can have ideas that don't work out, and people with good intentions can make decisions that backfire. It does not add a lot of value generally to speculate about peoples motives or capabilities when discussing the merits of their ideas, and doing so will be considered off-topic in technical discussions.
+- Comments should contribute new information. A certain amount of repetition is critical for learning, dissemination of ideas, and understanding in communication, but it can be taken too far when the same information is repeated in the same context. Moderators may remove comments that do not either contribute new information or constructively reframe existing information.
+- Comments about moderation decisions or moderation policy are off-topic in Bitcoin Core software projects and will be deleted. If you wish to discuss moderation, please file an issue in TODO: make a dedicated repository, which is the home for project management issues, and nontechnical discussions relating to development of the codebase.
+
+## Role of Moderators
+
+Members of the Lightning protocol specification communication channel will be helpful in reporting and flagging misbehavior. Volunteer moderators will review flagged posts as well as spot check other conversations to determine whether the posts in question should be hidden, deleted, or left as is.
+
+Moderation will necessarily be imperfect and inconsistent, because there is value in having direct and spirited exchange, but also value in fostering an atmosphere of respect and civility. In general, however, moderators will favor action over inaction, because it is easier to repost information to meet desired norms of discussion, than it is to uphold norms that are not adequately enforced.
+
+TODO: add an open nomination process for moderators
+
+## Moderation procedure
+
+Moderators will act on unwelcome posts when they are seen.
+
+Spam will be deleted and posters accounts will be reported to GitHub. Users who are determined to create an account in order to leave inflammatory comments on controversial topics will also have their comment either hidden or deleted and may be blocked from the Bitcoin organization.
+
+Moderators may lock controversial conversations or limit it to prior contributors or members of the Lightning github organization.
+
+Moderators may reach out to contributors to ask them to self-moderate. In requesting self-moderation from contributors, moderators may ask for specific actions like editing or deleting the post in question, so as to avoid public shaming directed at the author or other escalations. Apologies can also be helpful to get the conversation back on track.
+
+For borderline posts that are not outright spam or attacks, but don't meet standards of discussion, moderators may choose to hide the comments, which renders them collapsed and minimized in discussion threads. In cases where it may not be obvious why a comment was hidden, moderators should point out specific problems so it is clear how they can be addressed.
+
+If moderation of individual posts fails, moderators will use warnings, timeouts and bans at increasing rates based on prior patterns of behavior. Usually mildly uncivil behavior (such as being off-topic/disruptive or rudeness) will result in a warning or temporary ban (in the order of days). Longer term bans may result from repeated or frequent violations. Moderators will consult with a maintainer from each major Lightning implementation before making any bans longer than 1 week.
+
+## Moderation transparency
+
+The job of moderators is to enforce the community's desired norms of discussion, not to preach or try to control people's behavior. However, because moderators will make a lot of subjective decisions, and will be given a lot of leeway to make those decisions, it is critical for them to be clear about how decisions are made. To this end:
+
+- When moderators lock a thread, they should also add a post saying that it is locked, saying why it is locked, and if possible, suggesting constructive actions that people who are concerned about the topic can take. This may include suggesting alternate locations the topic could be discussed, or possible solutions in the prior discussion that could be followed up on.
+
+- When moderators hide a comment which has a mix of potentially useful information and inflammatory rhetoric, they should say somewhere, in a sentence or two, which parts of the message were over the line, so there is less chance of misunderstanding by the poster, and so problems could be potentially corrected. This could be done in a separate post. Or, to avoid disrupting the flow of the conversation, it could be sent in a private message to the poster or added as a postscript to the original comment.
+
+- When moderators hide or delete a comment which does not add any value at all, they should not need to write any explanation as these actions should be self-explanatory. But they could choose to explain what happened if they think it would be helpful.
+
+- When moderators ban someone for a reason other than obvious spam, there should be an issue posted TODO: add side lightning repository for moderation issues to provide a public indication that some discussion was suppressed. This could be in dedicated issues, or in a catch-all issue for temporary bans. To avoid embarrassment or potential backlash, the post does need not include name of the person being banned or reasons for the ban.
+
+- Moderators should not edit the contents of contributors posts. The only exception should be that if moderators are hiding a comment, they can add a clearly delineated postscript to the comment with the moderator's username, the date, and short explanation of why they are hiding the comment.
+
+## Feedback
+
+No system of moderation can be perfect or meet everyone's expectations. Too much discussion about moderation can also be a distraction and not a good use of contributors limited time. So discussion about moderation policies or decision should generally be avoided within Lightning's GitHub protocol specification projects, but discussion about moderation, and other topics that could make contributing to Bitcoin Core more productive and pleasant is welcome in the Lightning GitHub project about project management issues (TODO: add specific link)
+
+## Oversight
+
+Moderators are not perfect and will make mistakes.
+
+If moderation decisions are causing repeated problems, please request a review of moderation decisions by opening a public issue in TODO: side public repository or email TODO: add email endpoint privately, so patterns of bad decisions can be discussed and corrected. Please include as much detail as you can provide about the specific moderation decisions which were unfair or counterproductive. If you think it is relevant, you can also include background information about things like past disagreements or conflicts of interest. Focus of the review will only be to improve moderation decisions and quality of discussion so please only include background information that is likely to be relevant to making better moderation decisions.
+
+If a review uncovers problems, it could result in new moderation guidelines being written or moderators being asked to change their behavior less formally. In more extreme cases, it could result in a specific moderator being asked not to moderate specific posters, leaving it to other moderators with less history who can be more credibly neutral. In the worst case, if moderators' decisions are really outside the best-effort practices described in this document, maintainers representing each one of the major Lightning implementation can remove moderators.
+
+## Recommended actions
+
+If your post is removed because it is on the edge of technical and substantive discussion: Try not to take it personally. Re-post a version of your comment that makes the same point in a more technical and substantive way.
+
+If your post is removed because it is considered off-topic: Try to find a better place where the topic can be discussed, and attempt to look for traction in those places.
+
+If your post is removed because it is too long or repetitive: Take some time to iterate offline and then post a concise, refined summary of your thoughts with links to outside discussions and texts for readers interested in more details.


### PR DESCRIPTION
This is another proposal to have moderation rules on Lightning communication channels. This proposal is a direct copycat of the moderation rules that have been adopted in the bitcoin core space recently (https://github.com/bitcoin-core/meta/blob/main/MODERATION-GUIDELINES.md) and this  a counter-proposal to #1207.

I think they have the notable advantage to be far more consistent, neutral and bright rather than the “code of conduct” proposal. Notably this is this proposal is far less tainted by one cultural perspective.

There are few TODOS left, notably adding side public repository as it has been done for bitcoin core project.

For the nomination of the first batch of moderators, _of which I’m not candidate_, but I think the following nomination heuristics could be the followed
- one moderator for each major lightning implementation (CLN, LND, LDK, Eclair) at the full discretion of the implementation team or community of contributors
- 1 or 2 non-implementation affiliated moderators

For the non-affiliated moderators, I don’t know what is a fitting nomination process ? Like people who wish to take up the task, at the condition they have substantially contributed in the past to the specification or Lightning protocol in a technical fashion, can comment on this PR or another issue. And then we can have a +1 by github profile from regular contributors to cast the moderated. It’s possible to do the +1 process in a more private fashion too if we assign throwaway pgp keys to everyone for this purpose.

I’ll strongly advocate that it’s better to have such trust-minimized moderation rules as it’s an open-source effort among many stakeholders and developers. Does Lightning Labs _trust_ Blockstream ? Does Acinq _trust_ Spiral ? Does Spiral _trust_ Lightning Labs ? I believe history of lightning protocol development has answered with a clear _no_ to those questions.