### PR TITLE
fix code typo in 04-onion-routing.md

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -854,7 +854,7 @@ func NewOnionPacket(paymentPath []*btcec.PublicKey, sessionKey *btcec.PrivateKey
         
         // Our starting packet needs to be filled out with random bytes, we
         // generate some deterministically using the session private key.
-        paddingKey := generateKey("pad", sessionKey.Serialize()
+        paddingKey := generateKey("pad", sessionKey.Serialize())
         paddingBytes := generateCipherStream(paddingKey, routingInfoSize)
         copy(mixHeader[:], paddingBytes)
 


### PR DESCRIPTION
Added missing parentheses in sample code for func NewOnionPacket