### PR TITLE
Fix typo in peer storage spec, update tools/extract-formats.py 

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -522,14 +522,14 @@ peers to return the latest data to them using the `peer_storage_retrieval` messa
 
 1. type: 7 (`peer_storage`)
 2. data:
-   * [`u16`: `length`]
-   * [`length*byte`:`blob`]
+    * [`u16`:`length`]
+    * [`length*byte`:`blob`]
 
 
 1. type: 9 (`peer_storage_retrieval`)
 2. data:
-   * [`u16`: `length`]
-   * [`length*byte`:`blob`]
+    * [`u16`:`length`]
+    * [`length*byte`:`blob`]
 
 
 Requirements:

--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -24,17 +24,17 @@ import fileinput
 
 # We allow either ordered or unordered lists.
 typeline = re.compile(
-    '(1\.|\*) type: (?P<value>[-0-9A-Za-z_|]+) \(`(?P<name>[A-Za-z0-9_]+)`\)( \(`?(?P<option>[^)`]*)`\))?')
+    r'(1\.|\*) type: (?P<value>[-0-9A-Za-z_|]+) \(`(?P<name>[A-Za-z0-9_]+)`\)( \(`?(?P<option>[^)`]*)`\))?')
 tlvline = re.compile(
-    '(1\.|\*) `tlv_stream`: `(?P<name>[A-Za-z0-9_]+)`')
+    r'(1\.|\*) `tlv_stream`: `(?P<name>[A-Za-z0-9_]+)`')
 subtypeline = re.compile(
-    '(1\.|\*) subtype: `(?P<name>[A-Za-z0-9_]+)`')
+    r'(1\.|\*) subtype: `(?P<name>[A-Za-z0-9_]+)`')
 dataline = re.compile(
-    '\s+([0-9]+\.|\*) \[`(?P<typefield>[-._a-zA-Z0-9*+]+)`:`(?P<name>[_a-z0-9]+)`\]')
+    r'\s+([0-9]+\.|\*) \[`(?P<typefield>[-._a-zA-Z0-9*+]+)`:`(?P<name>[_a-z0-9]+)`\]')
 datastartline = re.compile(
-    '(2\.|\*) data:')
+    r'(2\.|\*) data:')
 tlvtypesline = re.compile(
-    '(2\.|\*) types:')
+    r'(2\.|\*) types:')
 
 # Generator to give us one line at a time.
 def next_line(args, lines):


### PR DESCRIPTION
The extra space after the : is non-standard, so fix that (also make indentation match).  And Python now complains about "useless" escapes in strings unless we tell it it's a regex, so fix that.