### PR TITLE
BOLT 12: re-add recurrence support.

### DIFF
--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -364,8 +364,8 @@ A writer of an offer:
     - MUST NOT set `offer_quantity_max`.
   - If an offer MAY trigger time-spaced invoice requests:
     - MUST include exactly one of `offer_recurrence_optional` or `offer_recurrence_compulsory`.
-	- MAY use `offer_recurrence_optional` if a payment of a single period would be useful (compatibility with pre-recurrence readers).
-	- MUST NOT use `offer_recurrence_optional` if `offer_recurrence_base` is present.
+    - MAY use `offer_recurrence_optional` if a payment of a single period would be useful (compatibility with pre-recurrence readers).
+    - MUST NOT use `offer_recurrence_optional` if `offer_recurrence_base` is present.
   - if it includes either `offer_recurrence_optional` or `offer_recurrence_compulsory`:
       - MUST set `time_unit` to 0 (seconds), 1 (days), 2 (months) or 3 (years).
       - MUST set `period` to how often (in `time-unit`) it wants to be paid.
@@ -470,7 +470,7 @@ painful to have to special-case the "only one left" offer generation.
 
 Offers can be used to simply send money without expecting anything in return (tips, kudos, donations, etc), which means the description field is optional (the `offer_issuer` field is very useful for this case!); if you are charging for something specific, the description is vital for the user to know what it was they paid for.
 
-We insist that recurring requests be in order (thus, if you pay an invoice for #34 of a recurring offer, it implicitly commits to the successful payment of #0 through #33).  The `invreq_recurrence_paywindow` constrains how far you can pay in advance precisely, and if it isn't in the offer the defaults provide some slack, without allowing commitments into the far future.
+We insist that recurring requests be in order (thus, if you pay an invoice for #34 of a recurring offer, it implicitly commits to the successful payment of #0 through #33).  The `offer_recurrence_paywindow` constrains how far you can pay in advance precisely, and if it isn't in the offer the defaults provide some slack, without allowing commitments into the far future.
 
 # Invoice Requests
 

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -378,8 +378,9 @@ A writer of an offer:
     - MAY use `offer_recurrence_optional` if a payment of a single period would be useful (compatibility with pre-recurrence readers).
     - MUST NOT use `offer_recurrence_optional` if `offer_recurrence_base` is present.
   - if it includes either `offer_recurrence_optional` or `offer_recurrence_compulsory`:
-      - MUST set `time_unit` to 0 (seconds), 1 (days), 2 (months) or 3 (years).
+      - MUST set `time_unit` to 0 (seconds), 1 (days)  or 2 (months).
       - MUST set `period` to how often (in `time-unit`) it wants to be paid.
+      - MUST NOT set `period` to 0.
       - if there is a maximum number of payments:
         - MUST include `offer_recurrence_limit` with `max_period_index` set to the maximum number of payments
         - MUST NOT set `max_period_index` to 0.
@@ -440,7 +441,9 @@ A reader of an offer:
   - if the current time is after `offer_absolute_expiry`:
     - MUST NOT make an initial response to the offer (i.e. continuing an existing offer with recurrence is ok)
   - if `offer_recurrence_optional` or `offer_recurrence_compulsory` are set:
-    - if `time_unit` is not one of 0, 1, 2 or 3:
+    - if `time_unit` is not one of 0, 1, or 2:
+       - MUST NOT respond to the offer.
+    - if `period` is 0:
        - MUST NOT respond to the offer.
     - if `offer_recurrence_limit` is set and `max_period_index` is 0:
        - MUST NOT respond to the offer.

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -233,17 +233,17 @@ The human-readable prefix for offers is `lno`.
     2. data:
         * [`byte`:`time_unit`]
         * [`tu32`:`period`]
-    1. type: 25 (`offer_recurrence_paywindow`)
-    2. data:
-        * [`u32`:`seconds_before`]
-        * [`tu32`:`seconds_after`]
-    1. type: 26 (`offer_recurrence_limit`)
-    2. data:
-        * [`tu32`:`max_period`]
-    1. type: 27 (`offer_recurrence_base`)
+    1. type: 26 (`offer_recurrence_base`)
     2. data:
         * [`byte`:`proportional_amount`]
         * [`tu64`:`basetime`]
+    1. type: 27 (`offer_recurrence_paywindow`)
+    2. data:
+        * [`u32`:`seconds_before`]
+        * [`tu32`:`seconds_after`]
+    1. type: 29 (`offer_recurrence_limit`)
+    2. data:
+        * [`tu32`:`max_period`]
 
 ### Recurrence
 
@@ -535,17 +535,17 @@ while still allowing signature validation.
     2. data:
         * [`byte`:`time_unit`]
         * [`tu32`:`period`]
-    1. type: 25 (`offer_recurrence_paywindow`)
-    2. data:
-        * [`u32`:`seconds_before`]
-        * [`tu32`:`seconds_after`]
-    1. type: 26 (`offer_recurrence_limit`)
-    2. data:
-        * [`tu32`:`max_period`]
-    1. type: 27 (`offer_recurrence_base`)
+    1. type: 26 (`offer_recurrence_base`)
     2. data:
         * [`byte`:`proportional_amount`]
         * [`tu64`:`basetime`]
+    1. type: 27 (`offer_recurrence_paywindow`)
+    2. data:
+        * [`u32`:`seconds_before`]
+        * [`tu32`:`seconds_after`]
+    1. type: 29 (`offer_recurrence_limit`)
+    2. data:
+        * [`tu32`:`max_period`]
     1. type: 80 (`invreq_chain`)
     2. data:
         * [`chain_hash`:`chain`]
@@ -806,17 +806,17 @@ the `onion_message` `invoice` field.
     2. data:
         * [`byte`:`time_unit`]
         * [`tu32`:`period`]
-    1. type: 25 (`offer_recurrence_paywindow`)
-    2. data:
-        * [`u32`:`seconds_before`]
-        * [`tu32`:`seconds_after`]
-    1. type: 26 (`offer_recurrence_limit`)
-    2. data:
-        * [`tu32`:`max_period`]
-    1. type: 27 (`offer_recurrence_base`)
+    1. type: 26 (`offer_recurrence_base`)
     2. data:
         * [`byte`:`proportional_amount`]
         * [`tu64`:`basetime`]
+    1. type: 27 (`offer_recurrence_paywindow`)
+    2. data:
+        * [`u32`:`seconds_before`]
+        * [`tu32`:`seconds_after`]
+    1. type: 29 (`offer_recurrence_limit`)
+    2. data:
+        * [`tu32`:`max_period`]
     1. type: 80 (`invreq_chain`)
     2. data:
         * [`chain_hash`:`chain`]

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -243,7 +243,7 @@ The human-readable prefix for offers is `lno`.
         * [`recurrence_paywindow`:`recurrence_paywindow`]
     1. type: 29 (`offer_recurrence_limit`)
     2. data:
-        * [`tu32`:`max_period`]
+        * [`tu32`:`max_period_index`]
 
 1. subtype: `recurrence`
 2. data:
@@ -286,7 +286,7 @@ Thus, each offer containing a recurring payment has:
    * `seconds_after`, defining how many seconds after the start of the period a payment will be accepted.
   If this field is missing, payment will be accepted during the prior period and the paid-for period.
 
-Note that the `offer_absolute_expiry` field already covers the case where an offer is no longer valid after January 1st 2021.
+Note: you can create an recurring offer with a fixed start which can only be used from the first period, using `offer_absolute_expiry`.  For example, my weekly book club starts January 1st 2026, for $5 a week: by setting `offer_absolute_expiry` to January 8th 2026, I ensure nobody can join after the first week.  Now, if only I could require them to actually read this week's book!
 
 For wallets which don't (yet) support recurrence, the basic recurrence field comes in two variants: `offer_recurrence_compulsory` if they should not attempt a payment, and `offer_recurrence_optional` if it still makes sense for them to attempt a single payment.
 
@@ -381,8 +381,8 @@ A writer of an offer:
       - MUST set `time_unit` to 0 (seconds), 1 (days), 2 (months) or 3 (years).
       - MUST set `period` to how often (in `time-unit`) it wants to be paid.
       - if there is a maximum number of payments:
-        - MUST include `offer_recurrence_limit` with `max_period` set to the maximum number of payments
-        - MUST NOT set `max_period` to 0.
+        - MUST include `offer_recurrence_limit` with `max_period_index` set to the maximum number of payments
+        - MUST NOT set `max_period_index` to 0.
       - otherwise:
         - MUST NOT include `offer_recurrence_limit`.
       - if periods are always at specific time offsets:
@@ -442,7 +442,7 @@ A reader of an offer:
   - if `offer_recurrence_optional` or `offer_recurrence_compulsory` are set:
     - if `time_unit` is not one of 0, 1, 2 or 3:
        - MUST NOT respond to the offer.
-    - if `offer_recurrence_limit` is set and `max_period` is 0:
+    - if `offer_recurrence_limit` is set and `max_period_index` is 0:
        - MUST NOT respond to the offer.
   - otherwise: (no recurrence):
     - if it `offer_recurrence_paywindow`, `offer_recurrence_limit` or `offer_recurrence_base` are set:
@@ -565,7 +565,7 @@ while still allowing signature validation.
         * [`recurrence_paywindow`:`recurrence_paywindow`]
     1. type: 29 (`offer_recurrence_limit`)
     2. data:
-        * [`tu32`:`max_period`]
+        * [`tu32`:`max_period_index`]
     1. type: 80 (`invreq_chain`)
     2. data:
         * [`chain_hash`:`chain`]
@@ -651,7 +651,7 @@ The writer:
       - otherwise:
         - MUST NOT include `invreq_recurrence_start`
       - if `offer_recurrence_limit` is present:
-        - MUST NOT send an `invoice_request` for a period greater than `max_period`
+        - MUST NOT send an `invoice_request` for a period index greater than `max_period_index`
       - SHOULD NOT send an `invoice_request` for a period which has already passed.
       - if `offer_recurrence_paywindow` is present:
         - if `recurrence_basetime` is present or `recurrence_counter` is non-zero:
@@ -735,7 +735,7 @@ The reader:
         - MUST reject the invoice request if there is a `invreq_recurrence_start` field.
         - MUST consider the period index for this request to be the `invreq_recurrence_counter` `counter` field.
       - if `offer_recurrence_limit` is present:
-        - MUST reject the invoice request if the period index is greater than `max_period`.
+        - MUST reject the invoice request if the period index is greater than `max_period_index`.
       - MUST calculate the period using the period index as detailed in [Period Calculation](#offer-period-calculation).
       - MUST reject the invoice request if an invoice has prevously been paid for this offer, `offer_issuer_id`, `invreq_metadata` and `invreq_recurrence_counter`.
       - if `invreq_recurrence_counter` is zero (initial request):
@@ -857,7 +857,7 @@ the `onion_message` `invoice` field.
         * [`recurrence_paywindow`:`recurrence_paywindow`]
     1. type: 29 (`offer_recurrence_limit`)
     2. data:
-        * [`tu32`:`max_period`]
+        * [`tu32`:`max_period_index`]
     1. type: 80 (`invreq_chain`)
     2. data:
         * [`chain_hash`:`chain`]

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -183,7 +183,7 @@ Signature = SIG("lightninginvoicesignature", Root, nodekey)
 
 Offers are a precursor to an invoice_request: readers will request an invoice
 (or multiple) based on the offer.  An offer can be much longer-lived than a
-particular invoice, so it has some different characteristics; in particular the amount can be in a non-lightning currency.  It's
+particular invoice, so it has some different characteristics; in particular it can be for a recurring payment, and the amount can be in a non-lightning currency.  It's
 also designed for compactness to fit inside a QR code easily.
 
 Note that the non-signature TLV elements get mirrored into
@@ -229,6 +229,88 @@ The human-readable prefix for offers is `lno`.
     1. type: 22 (`offer_issuer_id`)
     2. data:
         * [`point`:`id`]
+    1. type: 24 (`offer_recurrence`)
+    2. data:
+        * [`byte`:`time_unit`]
+        * [`tu32`:`period`]
+    1. type: 25 (`offer_recurrence_paywindow`)
+    2. data:
+        * [`byte`:`proportional_amount`]
+        * [`u32`:`seconds_before`]
+        * [`tu32`:`seconds_after`]
+    1. type: 26 (`offer_recurrence_limit`)
+    2. data:
+        * [`tu32`:`max_period`]
+    1. type: 27 (`offer_recurrence_base`)
+    2. data:
+        * [`byte`:`start_any_period`]
+        * [`tu64`:`basetime`]
+
+### Recurrence
+
+Some offers are *periodic*, such as a subscription service or monthly dues, in that payment is expected to be repeated.  There are many different flavors of repetition, consider:
+
+* Payments due on the first of every month, for 6 months.
+* Payments due on every Monday, 1pm Pacific Standard Time.
+* Payments due once a year:
+   * which must be made on January 1st, or
+   * which are only valid if started January 1st 2021, or
+   * which if paid after January 1st you (over) pay the full rate first year, or
+   * which if paid after January 1st are paid pro-rata for the first year, or
+   * which repeat from whenever you made the first payment
+
+Thus, each offer containing a recurring payment has:
+1. A `time_unit` defining 0 (seconds), 1 (days), 2 (months), 3 (years).
+2. A `period`, defining how often (in `time_unit`) it has to be paid.
+3. An optional `offer_recurrence_limit` of total payments to be paid.
+4. An optional `offer_recurrence_base`:
+   * `basetime`, defining when the first period starts in seconds since 1970-01-01 UTC.
+   * `start_any_period` if non-zero, meaning you don't have to start paying at the period indicated by `basetime`, but can use `offer_recurrence_start` to indicate what period you are starting at.
+5. An optional `offer_recurrence_paywindow`:
+   * `seconds_before`, defining how many seconds prior to the start of the period a payment will be accepted.
+   * `proportional_amount`, if set indicating that a payment made during the period itself will be charged proportionally to the remaining time in the period (e.g. 150 seconds into a 1500 second period gives a 10% discount).
+   * `seconds_after`, defining how many seconds after the start of the period a payment will be accepted.
+  If this field is missing, payment will be accepted during the prior period and the paid-for period.
+
+Note that the `offer_absolute_expiry` field already covers the case where an offer is no longer valid after January 1st 2021.
+
+### Offer Period Calculation
+
+Each period has a zero-based index, and a start time and an end time.  Because the periods can be in non-seconds units, the duration of a period can depend on when it starts.  The period with index N+1 begins immediately following the end of period with index N.
+
+- if an offer contains `offer_recurrence_base`:
+  - the start of period #0 is `basetime` seconds since 1970-01-01 UTC.
+- otherwise:
+  - the start of period #0 is the `invoice_created_at`.`timestamp` of the first `invoice` for this particular offer and `invreq_payer_id`.
+
+To calculate UTC time of the start of period #`N` for `N` > 0:
+- if `time_unit` is 0 (seconds):
+  - period `N` starts at period #0 start plus `period` multiplied by `N`, in seconds.
+- otherwise, if `time_unit` is 1 (days):
+  - calculate the offset in seconds within the day of period #0 start.
+  - add `period` multiplied by `N` days to get the day of the period start.
+  - add the offset in seconds to get the period end in seconds.
+- otherwise, if `time_unit` is 2 (months):
+  - calculate the offset in days within the month of period #0 start.
+  - calculate the offset in seconds within the day of period #0 start.
+  - add `period` multiplied by `N` months to get the month of the period start.
+  - add the offset days to get the day of the period start.
+    - if the day is not within the month, use the last day within the month.
+  - add the offset seconds to get the period start in seconds.
+- otherwise, if `time_unit` is 3 (years):
+  - calculate the offset in months within the year of period #0 start.
+  - calculate the offset in days within the month of period #0 start.
+  - calculate the offset in seconds within the day of period #0 start.
+  - add `period` multiplied by `N` years to get the year of the period start.
+  - add the offset months to get the month of the period start.
+  - add the offset days to get the day of the period start.
+    - if the day is not within the month, use the last day within the month.
+  - add the offset seconds to get the period start in seconds.
+- otherwise, the time is invalid.
+
+Note that offset seconds can overflow only if the period start is in a leap second; we ignore this!
+
+See [offer-period-test.json](bolt12/offer-period-test.json).
 
 ## Requirements For Offers
 
@@ -258,7 +340,7 @@ A writer of an offer:
     - MUST set `offer_features`.`features` to the bitmap of bolt12 features.
   - if the offer expires:
     - MUST set `offer_absolute_expiry` `seconds_from_epoch` to the number of seconds
-      after midnight 1 January 1970, UTC that invoice_request should not be
+      after midnight 1 January 1970, UTC that (initial) invoice_request should not be
       attempted.
   - if it is connected only by private channels:
     - MUST include `offer_paths` containing one or more paths to the node from
@@ -282,6 +364,41 @@ A writer of an offer:
       - MUST set `offer_quantity_max` to 0.
   - otherwise:
     - MUST NOT set `offer_quantity_max`.
+  - MAY include `offer_recurrence` to indicate offer should trigger time-spaced invoices.
+  - if it includes `offer_recurrence`:
+      - MUST set `time_unit` to 0 (seconds), 1 (days), 2 (months) or 3 (years).
+      - MUST set `period` to how often (in `time-unit`) it wants to be paid.
+      - if there is a maximum number of payments:
+        - MUST include `offer_recurrence_limit` with `max_period` set to the maximum number of payments
+        - MUST NOT set `max_period` to 0.
+      - otherwise:
+        - MUST NOT include `offer_recurrence_limit`.
+      - if periods are always at specific time offsets:
+        - MUST include `offer_recurrence_base`
+        - MUST set `basetime` to the initial period time in number of seconds after midnight 1 January 1970, UTC
+        - if the first paid-for-period does not have to be the initial period:
+          - MUST set `start_any_period` to 1.
+        - otherwise:
+          - MUST set `start_any_period` to 0.
+      - otherwise:
+        - MUST NOT include `offer_recurrence_base`.
+      - if payments will be accepted for any time in the current or next period:
+        - SHOULD NOT include `offer_recurrence_paywindow`
+      - otherwise:
+        - MUST include `offer_recurrence_paywindow`
+      - if it includes `offer_recurrence_paywindow`:
+        - MUST set `seconds_before` to the maximum number of seconds prior to a period for which it will accept payment or invoice_request for that period.
+        - MUST set `seconds_after` to the maximum number of seconds into to a period for which it will accept payment or invoice_request for that period.
+        - MAY NOT enforce this for the initial period for offers without `offer_recurrence_base`
+        - SHOULD NOT set `seconds_after` to greater than the maximum number of seconds in a period.
+        - if `amount` is specified and the node will proportionally reduce the amount charged for a period payed after the start of the period:
+          - MUST set `proportional_amount` to 1 
+        - otherwise:
+          - MUST set `proportional_amount` to 0
+  - otherwise:
+    - MUST NOT include `offer_recurrence_base`.
+    - MUST NOT include `offer_recurrence_paywindow`.
+    - MUST NOT include `offer_recurrence_limit`.
 
 A reader of an offer:
   - if the offer contains any TLV fields outside the inclusive ranges: 1 to 79 and 1000000000 to 1999999999:
@@ -313,7 +430,15 @@ A reader of an offer:
     - MUST warn the user if the received `invoice_amount` differs significantly
         from that estimate.
   - if the current time is after `offer_absolute_expiry`:
-    - MUST NOT respond to the offer.
+    - MUST NOT make an initial response to the offer (i.e. continuing an existing offer with `offer_recurrence` is ok)
+  - if `offer_recurrence` is set:
+    - if `time_unit` is not one of 0, 1, 2 or 3:
+       - MUST NOT respond to the offer.
+    - if `offer_recurrence_limit` is set and `max_period` is 0:
+       - MUST NOT respond to the offer.
+  - otherwise: (no `offer_recurrence`):
+    - if it `offer_recurrence_paywindow`, `offer_recurrence_limit` or `offer_recurrence_base` are set:
+       - MUST NOT respond to the offer.
   - if it chooses to send an invoice request, it sends an onion message:
     - if `offer_paths` is set:
       - MUST send the onion message via any path in `offer_paths` to the final `onion_msg_hop`.`blinded_node_id` in that path
@@ -347,6 +472,8 @@ useful in a system which bases it on available stock.  It would be
 painful to have to special-case the "only one left" offer generation.
 
 Offers can be used to simply send money without expecting anything in return (tips, kudos, donations, etc), which means the description field is optional (the `offer_issuer` field is very useful for this case!); if you are charging for something specific, the description is vital for the user to know what it was they paid for.
+
+We insist that recurring requests be in order (thus, if you pay an invoice for #34 of a recurring offer, it implicitly commits to the successful payment of #0 through #33).  The `invreq_recurrence_paywindow` constrains how far you can pay in advance precisely, and if it isn't in the offer the defaults provide some slack, without allowing commitments into the far future.
 
 # Invoice Requests
 
@@ -416,6 +543,22 @@ while still allowing signature validation.
     1. type: 22 (`offer_issuer_id`)
     2. data:
         * [`point`:`id`]
+    1. type: 24 (`offer_recurrence`)
+    2. data:
+        * [`byte`:`time_unit`]
+        * [`tu32`:`period`]
+    1. type: 25 (`offer_recurrence_paywindow`)
+    2. data:
+        * [`byte`:`proportional_amount`]
+        * [`u32`:`seconds_before`]
+        * [`tu32`:`seconds_after`]
+    1. type: 26 (`offer_recurrence_limit`)
+    2. data:
+        * [`tu32`:`max_period`]
+    1. type: 27 (`offer_recurrence_base`)
+    2. data:
+        * [`byte`:`start_any_period`]
+        * [`tu64`:`basetime`]
     1. type: 80 (`invreq_chain`)
     2. data:
         * [`chain_hash`:`chain`]
@@ -443,6 +586,12 @@ while still allowing signature validation.
         * [`name_len*byte`:`name`]
         * [`u8`:`domain_len`]
         * [`domain_len*byte`:`domain`]
+    1. type: 92 (`invreq_recurrence_counter`)
+    2. data:
+        * [`tu32`:`counter`]
+    1. type: 93 (`invreq_recurrence_start`)
+    2. data:
+        * [`tu32`:`period_offset`]
     1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -471,6 +620,31 @@ The writer:
         - MUST set `invreq_quantity` less than or equal to `offer_quantity_max`.
     - otherwise:
       - MUST NOT set `invreq_quantity`
+    - if `offer_recurrence` is present:
+      - for the initial request:
+        - MUST use a unique `invreq_payer_id`.
+        - MUST set `invreq_recurrence_counter` `counter` to 0.
+      - for any successive requests:
+        - MUST use the same `invreq_payer_id` as the initial request.
+        - MUST set `invreq_recurrence_counter` `counter` to one greater than the highest-paid invoice.
+      - if `offer_recurrence_base` is present with `start_any_period` non-zero:
+        - MUST include `invreq_recurrence_start`
+        - MUST set `period_offset` to the period the sender wants for the initial request
+        - MUST set `period_offset` to the same value on all following requests.
+      - otherwise:
+        - MUST NOT include `invreq_recurrence_start`
+      - if `offer_recurrence_limit` is present:
+        - MUST NOT send an `invoice_request` for a period greater than `max_period`
+      - SHOULD NOT send an `invoice_request` for a period which has already passed.
+      - if `offer_recurrence_paywindow` is present:
+        - if `recurrence_basetime` is present or `recurrence_counter` is non-zero:
+          - SHOULD NOT send an `invoice_request` for a period prior to `seconds_before` seconds before that period start.
+          - SHOULD NOT send an `invoice_request` for a period later than `seconds_after` seconds past that period start.
+      - otherwise:
+        - SHOULD NOT send an `invoice_request` with non-zero `recurrence_counter` for a period whose immediate predecessor has not yet begun.
+    - otherwise:
+      - MUST NOT set `invreq_recurrence_counter`.
+      - MUST NOT set `invreq_recurrence_start`
   - otherwise (not responding to an offer):
     - MUST set `offer_description` to a complete description of the purpose of the payment.
     - MUST set (or not set) `offer_absolute_expiry` and `offer_issuer` as it would for an offer.
@@ -502,7 +676,7 @@ The reader:
   - MUST reject the invoice request if `signature` is not correct as detailed in [Signature Calculation](#signature-calculation) using the `invreq_payer_id`.
   - if `num_hops` is 0 in any `blinded_path` in `invreq_paths`:
     - MUST reject the invoice request.
-  - if `offer_issuer_id` is present, and `invreq_metadata` is identical to a previous `invoice_request`:
+  - if `offer_issuer_id` is present, and `invreq_metadata` and `invreq_recurrence_counter` (if any) are identical to a previous `invoice_request`:
     - MAY simply reply with the previous invoice.
   - otherwise:
     - MUST NOT reply with a previous invoice.
@@ -523,11 +697,35 @@ The reader:
         - if `offer_currency` is not the `invreq_chain` currency, convert to the
           `invreq_chain` currency.
         - if `invreq_quantity` is present, multiply by `invreq_quantity`.`quantity`.
+        - if `offer_recurrence_paywindow` is present and `proportional_amount` is 1:
+          - MUST scale the *expected amount* proportional to time remaining in the period being paid for.
+          - MUST NOT increase the *expected amount* (i.e. only scale if we're in the period already).
       - if `invreq_amount` is present:
         - MUST reject the invoice request if `invreq_amount`.`msat` is less than the *expected amount*.
         - MAY reject the invoice request if `invreq_amount`.`msat` greatly exceeds the *expected amount*.
     - otherwise (no `offer_amount`):
       - MUST reject the invoice request if it does not contain `invreq_amount`.
+    - if `offer_recurrence` is present:
+      - MUST reject the invoice request if there is no `invreq_recurrence_counter` field.
+      - if `offer_recurrence_base` is present and `start_any_period` is 1:
+        - MUST reject the invoice request if there is no `invreq_recurrence_start` field.
+        - MUST consider the period index for this request to be the `invreq_recurrence_start` field plus the `invreq_recurrence_counter` `counter` field.
+      - otherwise:
+        - MUST reject the invoice request if there is a `invreq_recurrence_start` field.
+        - MUST consider the period index for this request to be the `invreq_recurrence_counter` `counter` field.
+      - if `offer_recurrence_limit` is present:
+        - MUST reject the invoice request if the period index is greater than `max_period`.
+      - MUST calculate the period using the period index as detailed in [Period Calculation](#offer-period-calculation).
+      - if `invreq_recurrence_counter` is non-zero:
+        - MUST reject the invoice request if no invoice for the previous period has been paid.
+        - if `offer_recurrence_paywindow` is present:
+          - SHOULD reject the invoice request if the current time is before the start of the period minus `seconds_before`.
+          - SHOULD reject the invoice request if the current time is equal to or after the start of the period plus `seconds_after`.
+        - otherwise:
+          - SHOULD reject the invoice request if the current time is prior to the start of the previous period.
+    - otherwise (no `offer_recurrence`):
+      - MUST reject the invoice request if there is a `invreq_recurrence_counter` field.
+      - MUST reject the invoice request if there is a `invreq_recurrence_start` field.
     - SHOULD send an invoice in response using the `onionmsg_tlv` `reply_path`.
   - otherwise (no `offer_issuer_id` or `offer_paths`, not a response to our offer):
     - MUST reject the invoice request if any of the following are present:
@@ -617,6 +815,22 @@ the `onion_message` `invoice` field.
     1. type: 22 (`offer_issuer_id`)
     2. data:
         * [`point`:`id`]
+    1. type: 24 (`offer_recurrence`)
+    2. data:
+        * [`byte`:`time_unit`]
+        * [`tu32`:`period`]
+    1. type: 25 (`offer_recurrence_paywindow`)
+    2. data:
+        * [`byte`:`proportional_amount`]
+        * [`u32`:`seconds_before`]
+        * [`tu32`:`seconds_after`]
+    1. type: 26 (`offer_recurrence_limit`)
+    2. data:
+        * [`tu32`:`max_period`]
+    1. type: 27 (`offer_recurrence_base`)
+    2. data:
+        * [`byte`:`start_any_period`]
+        * [`tu64`:`basetime`]
     1. type: 80 (`invreq_chain`)
     2. data:
         * [`chain_hash`:`chain`]
@@ -644,6 +858,12 @@ the `onion_message` `invoice` field.
         * [`name_len*byte`:`name`]
         * [`u8`:`domain_len`]
         * [`domain_len*byte`:`domain`]
+    1. type: 92 (`invreq_recurrence_counter`)
+    2. data:
+        * [`tu32`:`counter`]
+    1. type: 93 (`invreq_recurrence_start`)
+    2. data:
+        * [`tu32`:`period_offset`]
     1. type: 160 (`invoice_paths`)
     2. data:
         * [`...*blinded_path`:`paths`]
@@ -671,6 +891,9 @@ the `onion_message` `invoice` field.
     1. type: 176 (`invoice_node_id`)
     2. data:
         * [`point`:`node_id`]
+    1. type: 177 (`invoice_recurrence_basetime`)
+    2. data:
+        * [`tu64`:`basetime`]
     1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -740,6 +963,12 @@ A writer of an invoice:
     - for the bitcoin chain, it MUST set each `fallback_address` with
       `version` as a valid witness version and `address` as a valid witness
       program
+  - if `offer_recurrence` is present:
+    - MUST set `invoice_recurrence_basetime`.`basetime` to the start of period #0 as calculated by [Period Calculation](#offer-period-calculation).
+    - if it sets `invoice_relative_expiry`:
+      - MUST NOT set `invoice_relative_expiry`.`seconds_from_creation` more than the number of seconds after `invoice_created_at` that payment for this period will be accepted.
+  - otherwise:
+    - MUST not set `invoice_recurrence_basetime`.
   - MUST include `invoice_paths` containing one or more paths to the node.
     - MUST specify `invoice_paths` in order of most-preferred to least-preferred if it has a preference.
     - MUST include `invoice_blindedpay` with exactly one `blinded_payinfo` for each `blinded_path` in `paths`, in order.
@@ -788,18 +1017,29 @@ A reader of an invoice:
     - MUST NOT use multiple parts to pay the invoice.
   - if `invreq_amount` is present:
     - MUST reject the invoice if `invoice_amount` is not equal to `invreq_amount`
-  - otherwise:
-    - SHOULD confirm authorization if `invoice_amount`.`msat` is not within the amount range authorized.
   - for the bitcoin chain, if the invoice specifies `invoice_fallbacks`:
     - MUST ignore any `fallback_address` for which `version` is greater than 16.
     - MUST ignore any `fallback_address` for which `address` is less than 2 or greater than 40 bytes.
     - MUST ignore any `fallback_address` for which `address` does not meet known requirements for the given `version`
+  - if `offer_recurrence` is present:
+    - MUST reject the invoice if `invoice_recurrence_basetime` is not present.
+    - if `invreq_recurrence_counter` is 0:
+      - if `offer_recurrence_base` is present:
+        - MUST reject the invoice if `invoice_recurrence_basetime`.`basetime` is not equal to `offer_recurrence_base`.`basetime`
+      - otherwise:
+        - MUST reject the invoice if `invoice_recurrence_basetime`.`basetime` is not equal to `invoice_created_at`.
+    - otherwise (successive invoices):
+      - SHOULD reject the invoice if `invoice_recurrence_basetime`.`basetime` is not equal to that of the previous period's invoice.
   - if `invreq_paths` is present:
     - MUST reject the invoice if it did not arrive via one of those paths.
   - otherwise, neither `offer_issuer_id` nor `offer_paths` are present (not derived from an offer):
     - MUST reject the invoice if it arrived via a blinded path.
   - otherwise (derived from an offer):
     - MUST reject the invoice if it did not arrive via invoice request `onionmsg_tlv` `reply_path`.
+  - if it pays the invoice:
+    - MUST have authorization for the payment purpose, recipient and amount.
+    - if `offer_recurrence` is present:
+      - SHOULD obtain single authorization which covers all expected payments.
 
 ## Rationale
 
@@ -825,7 +1065,7 @@ amount from either the offer it received, or the invreq it
 sent, so often already has authorization for the expected amount.
 
 The default `invoice_relative_expiry` of 7200 seconds, which is generally a
-sufficient time for payment, even if new channels need to be opened.
+sufficient time for payment, even if new channels need to be opened.  In the case of periodic payments, which have a natural time limit, this value is capped to that, but a lesser cap may be useful in the case of currency fluctuations.
 
 Blinded paths provide an equivalent to `payment_secret` and `payment_metadata` used in BOLT 11.
 Even if `invoice_node_id` or `invreq_payer_id` is public, we force the use of blinding paths to keep these features.
@@ -833,6 +1073,8 @@ If the recipient does not care about the added privacy offered by blinded paths,
 
 Rather than provide detailed per-hop-payinfo for each hop in a blinded path, we aggregate the fees and CLTV deltas.
 This avoids trivially revealing any distinguishing non-uniformity which may distinguish the path.
+
+For recurrence, the `invoice_recurrence_basetime` field is a courtesy so the payer doesn't have to remember the timing of the original invoice to calculate when the recurrence period starts (and thus when the next invoice_request is due): it can calculate this from any invoice.
 
 In the case of an invoice where there was no offer (just an invoice
 request), the payer needs to ensure that the invoice is from the
@@ -847,6 +1089,11 @@ a response to an invoice request, that field must have existed due
 to the invoice request requirements, and we also require it to be mirrored
 here.
 
+Authorization can be very general ("install this app to spray sats to the world!") or very specific ("pay 10c to this person"), but it is a cornerstone requirement for wallets.  Unauthorized payments are at best a bug, at worst theft.  With the addition of recurring payments we made this explicit, to avoid a system where a vendor can pull arbitrary amounts from a user.  Thus, authorization requires a complete, up-front description of the recurrence.
+
+For example, consider an offer with weekly recurrence (`time_unit`=1, `period`=7), `amount` 500, `currency` `AUD` ($5 Australian dollars).  An implementation may present this to the user as USD $3.53 (max $3.71), to allow up to 5% exchange slippage, and receive their authorization.  As it received each invoice, it would convert the `msat` into USD to check that it was below the maximum authorization of USD$3.71.  If it was, it would simply pay the invoice without user interaction.  If not, it requires re-authorization.
+
+Note that the implementation of a trusted exchange rate service is left to the reader.
 
 # Invoice Errors
 
@@ -905,9 +1152,7 @@ with the conversion so the sender can send a new invoice.
    other means (i.e. transport-specific), but is still hashed for sig.
 4. We could upgrade to allow multiple offers in one invreq and
    invoice, to make a shopping list.
-7. All-zero offer_id == gratuitous payment.
 8. Streaming invoices?
-9. Re-add recurrence.
 10. Re-add `invreq_refund_for` to support proofs.
 11. Re-add `invoice_replace` for requesting replacement of a (stuck-payment) 
     invoice with a new one.

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -231,23 +231,34 @@ The human-readable prefix for offers is `lno`.
         * [`point`:`id`]
     1. type: 24 (`offer_recurrence_compulsory`)
     2. data:
-        * [`byte`:`time_unit`]
-        * [`tu32`:`period`]
+        * [`recurrence`:`recurrence`]
     1. type: 25 (`offer_recurrence_optional`)
     2. data:
-        * [`byte`:`time_unit`]
-        * [`tu32`:`period`]
+        * [`recurrence`:`recurrence`]
     1. type: 26 (`offer_recurrence_base`)
     2. data:
-        * [`byte`:`proportional_amount`]
-        * [`tu64`:`basetime`]
+        * [`recurrence_base`:`recurrence_base`]
     1. type: 27 (`offer_recurrence_paywindow`)
     2. data:
-        * [`u32`:`seconds_before`]
-        * [`tu32`:`seconds_after`]
+        * [`recurrence_paywindow`:`recurrence_paywindow`]
     1. type: 29 (`offer_recurrence_limit`)
     2. data:
         * [`tu32`:`max_period`]
+
+1. subtype: `recurrence`
+2. data:
+    * [`byte`:`time_unit`]
+    * [`tu32`:`period`]
+
+1. subtype: `recurrence_base`
+2. data:
+    * [`byte`:`proportional_amount`]
+    * [`tu64`:`basetime`]
+
+1. subtype: `recurrence_paywindow`
+2. data:
+    * [`u32`:`seconds_before`]
+    * [`tu32`:`seconds_after`]
 
 ### Recurrence
 
@@ -542,20 +553,16 @@ while still allowing signature validation.
         * [`point`:`id`]
     1. type: 24 (`offer_recurrence_compulsory`)
     2. data:
-        * [`byte`:`time_unit`]
-        * [`tu32`:`period`]
+        * [`recurrence`:`recurrence`]
     1. type: 25 (`offer_recurrence_optional`)
     2. data:
-        * [`byte`:`time_unit`]
-        * [`tu32`:`period`]
+        * [`recurrence`:`recurrence`]
     1. type: 26 (`offer_recurrence_base`)
     2. data:
-        * [`byte`:`proportional_amount`]
-        * [`tu64`:`basetime`]
+        * [`recurrence_base`:`recurrence_base`]
     1. type: 27 (`offer_recurrence_paywindow`)
     2. data:
-        * [`u32`:`seconds_before`]
-        * [`tu32`:`seconds_after`]
+        * [`recurrence_paywindow`:`recurrence_paywindow`]
     1. type: 29 (`offer_recurrence_limit`)
     2. data:
         * [`tu32`:`max_period`]
@@ -582,10 +589,7 @@ while still allowing signature validation.
         * [`...*blinded_path`:`paths`]
     1. type: 91 (`invreq_bip_353_name`)
     2. data:
-        * [`u8`:`name_len`]
-        * [`name_len*byte`:`name`]
-        * [`u8`:`domain_len`]
-        * [`domain_len*byte`:`domain`]
+        * [`bip_353_name`:`bip_353_name`]
     1. type: 92 (`invreq_recurrence_counter`)
     2. data:
         * [`tu32`:`counter`]
@@ -596,6 +600,13 @@ while still allowing signature validation.
     1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
+
+1. subtype: `bip_353_name`
+2. data:
+    * [`u8`:`name_len`]
+    * [`name_len*byte`:`name`]
+    * [`u8`:`domain_len`]
+    * [`domain_len*byte`:`domain`]
 
 ## Requirements for Invoice Requests
 
@@ -827,20 +838,16 @@ the `onion_message` `invoice` field.
         * [`point`:`id`]
     1. type: 24 (`offer_recurrence_compulsory`)
     2. data:
-        * [`byte`:`time_unit`]
-        * [`tu32`:`period`]
+        * [`recurrence`:`recurrence`]
     1. type: 25 (`offer_recurrence_optional`)
     2. data:
-        * [`byte`:`time_unit`]
-        * [`tu32`:`period`]
+        * [`recurrence`:`recurrence`]
     1. type: 26 (`offer_recurrence_base`)
     2. data:
-        * [`byte`:`proportional_amount`]
-        * [`tu64`:`basetime`]
+        * [`recurrence_base`:`recurrence_base`]
     1. type: 27 (`offer_recurrence_paywindow`)
     2. data:
-        * [`u32`:`seconds_before`]
-        * [`tu32`:`seconds_after`]
+        * [`recurrence_paywindow`:`recurrence_paywindow`]
     1. type: 29 (`offer_recurrence_limit`)
     2. data:
         * [`tu32`:`max_period`]
@@ -867,10 +874,7 @@ the `onion_message` `invoice` field.
         * [`...*blinded_path`:`paths`]
     1. type: 91 (`invreq_bip_353_name`)
     2. data:
-        * [`u8`:`name_len`]
-        * [`name_len*byte`:`name`]
-        * [`u8`:`domain_len`]
-        * [`domain_len*byte`:`domain`]
+        * [`bip_353_name`:`bip_353_name`]
     1. type: 92 (`invreq_recurrence_counter`)
     2. data:
         * [`tu32`:`counter`]

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -657,7 +657,7 @@ The writer:
         - MUST NOT send an `invoice_request` for a period index greater than `max_period_index`
       - SHOULD NOT send an `invoice_request` for a period which has already passed.
       - if `offer_recurrence_paywindow` is present:
-        - if `recurrence_basetime` is present or `recurrence_counter` is non-zero:
+        - if `offer_recurrence_base` is present or `recurrence_counter` is non-zero:
           - SHOULD NOT send an `invoice_request` for a period prior to `seconds_before` seconds before that period start.
           - SHOULD NOT send an `invoice_request` for a period later than `seconds_after` seconds past that period start.
       - otherwise:

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -600,6 +600,9 @@ while still allowing signature validation.
     2. data:
         * [`tu32`:`period_offset`]
     1. type: 94 (`invreq_recurrence_cancel`)
+    1. type: 96 (`invreq_recurrence_prev_state`)
+    2. data:
+        * [`...*byte`:`state`]
     1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -647,6 +650,7 @@ The writer:
         - MUST use the same `invreq_payer_id` as the initial request.
         - MUST set `invreq_recurrence_counter` `counter` to one greater than the highest-paid invoice.
         - MAY set `invreq_recurrence_cancel`.
+        - MUST set or not set `invreq_recurrence_prev_state` as `invoice_recurrence_next_state` of the highest-paid invoice.
       - if `offer_recurrence_base` is present:
         - MUST include `invreq_recurrence_start`
         - MUST set `period_offset` to the period the sender wants for the initial request
@@ -731,6 +735,7 @@ The reader:
       - MUST reject the invoice request if the current time is after `offer_absolute_expiry`.
     - if `offer_recurrence_optional` or `offer_recurrence_compulsory` are present:
       - MUST reject the invoice request if there is no `invreq_recurrence_counter` field.
+      - SHOULD reject the invoice request if `invreq_recurrence_prev_state` is not identical to (or identically missing) the `invoice_recurrence_next_state` of the highest-paid invoice.
       - if `offer_recurrence_base` is present:
         - MUST reject the invoice request if there is no `invreq_recurrence_start` field.
         - MUST consider the period index for this request to be the `invreq_recurrence_start` field plus the `invreq_recurrence_counter` `counter` field.
@@ -740,7 +745,7 @@ The reader:
       - if `offer_recurrence_limit` is present:
         - MUST reject the invoice request if the period index is greater than `max_period_index`.
       - MUST calculate the period using the period index as detailed in [Period Calculation](#offer-period-calculation).
-      - MUST reject the invoice request if an invoice has prevously been paid for this offer, `offer_issuer_id`, `invreq_metadata` and `invreq_recurrence_counter`.
+      - SHOULD reject the invoice request if an invoice has prevously been paid for this offer, `offer_issuer_id`, `invreq_metadata` and `invreq_recurrence_counter`.
       - if `invreq_recurrence_counter` is zero (initial request):
         - MUST reject the invoice request if `invreq_recurrence_cancel` is present.
       - otherwise: (successive requests)
@@ -921,6 +926,9 @@ the `onion_message` `invoice` field.
     1. type: 177 (`invoice_recurrence_basetime`)
     2. data:
         * [`tu64`:`basetime`]
+    1. type: 178 (`invoice_recurrence_next_state`)
+    2. data:
+        * [`...*byte`:`state`]
     1. type: 240 (`signature`)
     2. data:
         * [`bip340sig`:`sig`]
@@ -994,8 +1002,10 @@ A writer of an invoice:
     - MUST set `invoice_recurrence_basetime`.`basetime` to the start of period #0 as calculated by [Period Calculation](#offer-period-calculation).
     - if it sets `invoice_relative_expiry`:
       - MUST NOT set `invoice_relative_expiry`.`seconds_from_creation` more than the number of seconds after `invoice_created_at` that payment for this period will be accepted.
+    - MUST set or not set `invoice_recurrence_next_state` to the expected `invreq_recurrence_prev_state` for the next invoice request.
   - otherwise:
     - MUST not set `invoice_recurrence_basetime`.
+    - MUST not set `invoice_recurrence_next_state`.
   - MUST include `invoice_paths` containing one or more paths to the node.
     - MUST specify `invoice_paths` in order of most-preferred to least-preferred if it has a preference.
     - MUST include `invoice_blindedpay` with exactly one `blinded_payinfo` for each `blinded_path` in `paths`, in order.
@@ -1050,6 +1060,8 @@ A reader of an invoice:
     - MUST ignore any `fallback_address` for which `address` does not meet known requirements for the given `version`
   - if `offer_recurrence_optional` or `offer_recurrence_compulsory` are present:
     - MUST reject the invoice if `invoice_recurrence_basetime` is not present.
+    - if `invoice_recurrence_next_state` is present:
+      - MUST save the contents for the next `invreq_recurrence_prev_state`.
     - if `invreq_recurrence_counter` is 0:
       - if `offer_recurrence_base` is present:
         - MUST reject the invoice if `invoice_recurrence_basetime`.`basetime` is not equal to `offer_recurrence_base`.`basetime`
@@ -1127,6 +1139,8 @@ For example, consider an offer with weekly recurrence (`time_unit`=1, `period`=7
 Note that the implementation of a trusted exchange rate service is left to the reader.
 
 Users can cancel their recurring payment at any time, but as a courtesy to the offer issuer (to differentiate from technical or unintended missing payments), the following invoice_request *is sent*, but it explicitly indicates the intention to cancel (optionally using `invreq_payer_note`).  The delay in sending this until the next payment is due also discourages early cancellation of service.  Note that this cancellation message is best-effort, since no reply is received.
+
+Invoice issuers for recurring offers can use the `invoice_recurrence_next_state` field to avoid storing their own state, knowing that the payers will return it in the next `invreq_recurrence_prev_state`.
 
 # Invoice Errors
 


### PR DESCRIPTION
This is taken from the old draft, and updated with modern field numbers and names.

I've made some minor changes:
1. The `proportional_amount` field comes before `seconds_before` which seems more logical to me.
2. The `offer_absolute_expiry` is clarified to only apply to the *initial* invoice request: once you're recurring the other fields take over.

The complexities mainly come from two sources:

1. A requirement to be precise about when recurrence happens.  This is because we want a push system, not a pull, since only the former allows for real authorization by the user, and there are many different reasonable ways to do recurrence.
2. This is the first wallet feature which isn't just "fire and forget", but requires them to keep state and do unprompted actions.

One proposal I would like to add is a courtesy onion message when a user cancels a periodic payment.  This is generally useful to tell the difference between a deliberate cancellation and a user-related failure.