### PR TITLE
Gossip Infinite Loop Fix

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -92,7 +92,7 @@ A node:
     - If it has NOT previously received `announcement_signatures` for the funding transaction:
       - MUST send its own `announcement_signatures` message.
     - If it receives `announcement_signatures` for the funding transaction:
-      - MUST respond with its own `announcement_signatures` message.
+      - MUST respond with its own `announcement_signatures` message once per connection.
 
 A recipient node:
   - If the `short_channel_id` is NOT correct:


### PR DESCRIPTION
Update the spec to prevent an infinite message loop.

As previously specified, both nodes must send `announcement_signatures` back and forth to each other forever.

Update it to specify “once per connection” to prevent this loop.