### PR TITLE
bolt12: Add test vector for missing offer_amount with offer_currency

### DIFF
--- a/bolt12/offers-test.json
+++ b/bolt12/offers-test.json
@@ -574,6 +574,11 @@
     "bolt12": "lno1pqpzwyqkyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg"
   },
   {
+    "description": "Missing offer_amount with offer_currency",
+    "valid": false,
+    "bolt12": "lno1qcp4256ypgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg"
+  },
+  {
     "description": "Missing offer_issuer_id and no offer_path",
     "valid": false,
     "bolt12": "lno1pgx9getnwss8vetrw3hhyuc"


### PR DESCRIPTION
During differential fuzzing between C-lightning and rust-lightning, discovered that C-lightning incorrectly accepts offers with offer_currency set but offer_amount missing, while rust-lightning rejects them.

The BOLT 12 specification states in "Requirements For Offers":
> if `offer_currency` is set and `offer_amount` is not set:
>   - MUST NOT respond to the offer.

This pr adds a test vector for the invalid offer:
`lno1qcp4256ypgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg`

Which contains CURRENCY=USD but no amount field, and should be rejected by all compliant implementations. 

I got this test vector from:
https://github.com/ElementsProject/lightning/blob/c3362b057c2174589024254f4cab9eb8d955a26f/common/test/run-bolt12-encode-test.c#L439

