### PR TITLE
bolt11: clarify signature normalization requirements

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -221,6 +221,10 @@ A reader:
   description.
   - if a valid `n` field is provided:
     - MUST use the `n` field to validate the signature instead of performing signature recovery.
+    - the signature MUST be normalized lower-S form.
+  - otherwise:
+    - MUST perform signature recovery.
+    - signature recovery accepts both high-S and low-S signatures.
   - if a valid `s` field is not provided:
     - MUST fail the payment.
   - otherwise:


### PR DESCRIPTION
Explicitly document that signature validation requirements differ based on the presence of the `n` field:

- With `n` field: signature MUST be normalized lower-S form
- Without `n` field: signature recovery accepts both high-S and low-S

This clarifies existing implementation behavior where `secp256k1_ecdsa_verify` (used with `n` field) requires normalized signatures, while `secp256k1_ecdsa_recover` (used without `n` field) accepts both normalized
and non-normalized signatures.

cc @real-or-random