### PR TITLE
BOLT 4: add minitramp support.

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -54,6 +54,7 @@ The Context column decodes as follows:
 | 48/49 | `option_payment_metadata`         | Payment metadata in tlv record                            | 9        |                             | [BOLT #11](11-payment-encoding.md#tagged-fields)                      |
 | 50/51 | `option_zeroconf`                 | Understands zeroconf channel types                        | INT      | `option_scid_alias`         | [BOLT #2][bolt02-channel-ready]                                       |
 | 60/61 | `option_simple_close`             | Simplified closing negotiation                            | IN       | `option_shutdown_anysegwit` | [BOLT #2][bolt02-simple-close]                                        |
+| 58/59 | `option_minitrampoline`           | Will forward payments via encrypted instructions          | IN       |                             | [BOLT #4][bolt04-minitramp]                                        |
 
 ## Requirements
 
@@ -107,5 +108,6 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 [bolt07-sync]: 07-routing-gossip.md#initial-sync
 [bolt07-query]: 07-routing-gossip.md#query-messages
 [bolt04-mpp]: 04-onion-routing.md#basic-multi-part-payments
+[bolt04-minitramp]: 04-onion-routing.md#minitrampoline-support
 [bolt04-route-blinding]: 04-onion-routing.md#route-blinding
 [ml-sighash-single-harmful]: https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-September/002796.html


### PR DESCRIPTION
We use the same "encrypted blob inside onion" trick as blinded paths, but using TLV 1, so it's ignored for backward compatibility.  In this case, we need to tell the trampoline the `payment_secret` (and optional `payment_metadata`) to put in the onion, which gives it the possibility of probing, or even underpaying amountless invoices.  However, if the final hop *does* support TLV 1, it can detect interference and refuse attempts to pay that same invoice (since there's a dishonest trampoline), providing *some* honesty incentive.