### PR TITLE
bolt04: Fix requirements of failure message for final node

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1457,8 +1457,7 @@ An _erring node_ MAY:
 A _forwarding node_ MUST:
   - if `path_key` is set in the incoming `update_add_htlc`:
     - return an `invalid_onion_blinding` error.
-  - if `current_path_key` is set in the onion payload and it is not the
-    final node:
+  - if `current_path_key` is set in the onion payload:
     - return an `invalid_onion_blinding` error.
   - otherwise:
     - select one of the above error codes when creating an error message.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1464,12 +1464,6 @@ A _forwarding node_ MUST:
     - select one of the above error codes when creating an error message.
 
 A _forwarding node_ MAY, but a _final node_ MUST NOT:
-  - if the onion `version` byte is unknown:
-    - return an `invalid_onion_version` error.
-  - if the onion HMAC is incorrect:
-    - return an `invalid_onion_hmac` error.
-  - if the ephemeral key in the onion is unparsable:
-    - return an `invalid_onion_key` error.
   - if during forwarding to its receiving peer, an otherwise unspecified,
   transient error occurs in the outgoing channel (e.g. channel capacity reached,
   too many in-flight HTLCs, etc.):
@@ -1503,6 +1497,14 @@ A _forwarding node_ MAY, but a _final node_ MUST NOT:
   - if the channel is disabled:
     - report the current channel setting for the outgoing channel.
     - return a `channel_disabled` error.
+
+A _forwarding node_ and a _final node_ MAY:
+  - if the onion `version` byte is unknown:
+    - return an `invalid_onion_version` error.
+  - if the onion HMAC is incorrect:
+    - return an `invalid_onion_hmac` error.
+  - if the ephemeral key in the onion is unparsable:
+    - return an `invalid_onion_key` error.
 
 An _intermediate hop_ MUST NOT, but the _final node_:
   - if the payment hash has already been paid:

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1506,7 +1506,7 @@ A _forwarding node_ and a _final node_ MAY:
   - if the ephemeral key in the onion is unparsable:
     - return an `invalid_onion_key` error.
 
-An _intermediate hop_ MUST NOT, but the _final node_:
+An _forwarding node_ MUST NOT, but a _final node_ MUST:
   - if the payment hash has already been paid:
     - MAY treat the payment hash as unknown.
     - MAY succeed in accepting the HTLC.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1470,8 +1470,7 @@ An _erring node_ MAY:
 A _forwarding node_ MUST:
   - if `path_key` is set in the incoming `update_add_htlc`:
     - return an `invalid_onion_blinding` error.
-  - if `current_path_key` is set in the onion payload and it is not the
-    final node:
+  - if `current_path_key` is set in the onion payload:
     - return an `invalid_onion_blinding` error.
   - otherwise:
     - select one of the above error codes when creating an error message.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1519,7 +1519,7 @@ A _forwarding node_ and a _final node_ MAY:
   - if the ephemeral key in the onion is unparsable:
     - return an `invalid_onion_key` error.
 
-An _intermediate hop_ MUST NOT, but the _final node_:
+A _forwarding node_ MUST NOT, but a _final node_ MUST:
   - if the payment hash has already been paid:
     - MAY treat the payment hash as unknown.
     - MAY succeed in accepting the HTLC.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1477,12 +1477,6 @@ A _forwarding node_ MUST:
     - select one of the above error codes when creating an error message.
 
 A _forwarding node_ MAY, but a _final node_ MUST NOT:
-  - if the onion `version` byte is unknown:
-    - return an `invalid_onion_version` error.
-  - if the onion HMAC is incorrect:
-    - return an `invalid_onion_hmac` error.
-  - if the ephemeral key in the onion is unparsable:
-    - return an `invalid_onion_key` error.
   - if during forwarding to its receiving peer, an otherwise unspecified,
   transient error occurs in the outgoing channel (e.g. channel capacity reached,
   too many in-flight HTLCs, etc.):
@@ -1516,6 +1510,14 @@ A _forwarding node_ MAY, but a _final node_ MUST NOT:
   - if the channel is disabled:
     - report the current channel setting for the outgoing channel.
     - return a `channel_disabled` error.
+
+A _forwarding node_ and a _final node_ MAY:
+  - if the onion `version` byte is unknown:
+    - return an `invalid_onion_version` error.
+  - if the onion HMAC is incorrect:
+    - return an `invalid_onion_hmac` error.
+  - if the ephemeral key in the onion is unparsable:
+    - return an `invalid_onion_key` error.
 
 An _intermediate hop_ MUST NOT, but the _final node_:
   - if the payment hash has already been paid:


### PR DESCRIPTION
fixes #1290

Also fixed two other sources of confusion in separate commits:

* inconsistent usage of 'forwarding node' and 'intermediate hop'
* mentioning requirement "it is not a final node" again within "a _forwarding node_ MUST"-block