### PR TITLE
BOLT 4: further restrictions on overpayment

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -395,7 +395,8 @@ The final node:
       all HTLCs in the set.
     - if the total `amt_to_forward` of this HTLC set is equal to or greater
       than `total_msat`:
-      - SHOULD fulfill all HTLCs in the HTLC set
+      - SHOULD fulfill the minimal subset of those HTLCs in the HTLC set which are required for payment
+      - SHOULD reject other "unnecessary" HTLCs in the HTLC set.
     - otherwise, if the total `amt_to_forward` of this HTLC set is less than
       `total_msat`:
       - MUST NOT fulfill any HTLCs in the HTLC set
@@ -435,6 +436,13 @@ An implementation may choose not to fulfill an HTLC set which
 otherwise meets the amount criterion (eg. some other failure, or
 invoice timeout), however if it were to fulfill only some of them,
 intermediary nodes could simply claim the remaining ones.
+
+There are cases where the sender attempts payments for the same invoice from multiple wallets
+(usually because one part of the first payment is stuck).  For example, a wallet could send
+50% of the payment in one part which arrives at the destination, and another 50% which does
+not.  The sender tries another wallet, which pays 100% of the payment.  In this case, the 50%
+HTLC should be rejected, as the 100% is sufficient.  This can be determined by ordering the
+HTLCs in the set in descending amount order, and iterating until the amount requirement is fulfilled.
 
 ## Route Blinding
 

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1526,7 +1526,7 @@ An _intermediate hop_ MUST NOT, but the _final node_:
   - if the payment hash is unknown:
     - MUST fail the HTLC.
     - MUST return an `incorrect_or_unknown_payment_details` error.
-  - if the amount paid is more than twice the amount expected:
+  - if the amount paid exceeds the expected about by more than 5000msat or 1% (whatever is greater):
     - SHOULD fail the HTLC.
     - SHOULD return an `incorrect_or_unknown_payment_details` error.
       - Note: this allows the origin node to reduce information leakage by


### PR DESCRIPTION
Reports from the field (thanks @michael1011) of gross overpayment in reasonable user scenarios: a payment is taking too long, so they try with another wallet.

Two changes to avoid this.