### PR TITLE
Upgrade channel type when splicing

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1657,6 +1657,9 @@ to indicate that one of the splice transactions reached acceptable depth.
 
 1. `tlv_stream`: `splice_init_tlvs`
 2. types:
+   1. type: 1 (`channel_type`)
+   2. data:
+        * [`...*byte`:`type`]
    1. type: 2 (`require_confirmed_inputs`)
 
 `funding_contribution_satoshis` is the amount the sender is adding to their
@@ -1681,6 +1684,8 @@ The sending node:
       the amount that will be added to its current channel balance.
   - If it requires the receiving node to only use confirmed inputs:
     - MUST set `require_confirmed_inputs`.
+  - If it wants to change the `channel_type` of the channel:
+    - MUST set `channel_type` to the `channel_type` it wants to use.
   - SHOULD use a different `funding_pubkey` than the one used for the
     previous funding transaction.
 
@@ -1702,6 +1707,8 @@ The receiving node:
       and fail the channel.
   - If the `funding_feerate_perkw` is unacceptable:
     - MUST respond with `tx_abort`.
+  - If it doesn't want to update the channel to the provided `channel_type`:
+    - MUST respond with `tx_abort`.
   - If `funding_contribution_satoshis` is negative and its absolute value is
     greater than the sending node's current channel balance:
     - MUST send a `warning` and close the connection or send an `error`
@@ -1722,6 +1729,9 @@ The receiving node:
 
 1. `tlv_stream`: `splice_ack_tlvs`
 2. types:
+   1. type: 1 (`channel_type`)
+   2. data:
+        * [`...*byte`:`type`]
    1. type: 2 (`require_confirmed_inputs`)
 
 #### Requirements
@@ -1733,11 +1743,19 @@ The sending node:
     to contribute to the splice.
   - If it requires the receiving node to only use confirmed inputs:
     - MUST set `require_confirmed_inputs`.
+  - If `channel_type` was set in `splice_init`:
+    - MUST set `channel_type` to the `channel_type` from `splice_init`.
 
 The receiving node:
   - If it has sent `splice_init`:
     - If `funding_contribution_satoshis` is negative and its absolute value is
       greater than the sending node's current channel balance:
+      - MUST send a `warning` and close the connection or send an `error`
+        and fail the channel.
+    - If `channel_type` is set but `channel_type` was not set in `splice_init`:
+      - MUST send a `warning` and close the connection or send an `error`
+        and fail the channel.    
+    - If `channel_type` does not match the `channel_type` from `splice_init`:
       - MUST send a `warning` and close the connection or send an `error`
         and fail the channel.
     - If it accepts the splice attempt:
@@ -1845,6 +1863,8 @@ The sending node:
       to the main balance of their respective sender.
     - Uses the same feerate as the existing commitment transaction.
     - Uses the same `commitment_number` as the existing commitment transaction.
+    - If `channel_type` was set in `splice_init` and `splice_ack`:
+      - MUST use that `channel_type` instead of the previous `channel_type`.
   - MUST send signatures for pending HTLCs.
   - MUST remember the details of this splice transaction.
 


### PR DESCRIPTION
We add a basic mechanism to opportunistically update the `channel_type` when splicing. This uses the same TLV field as open/accept channel and a similar mechanism. We don't explicitly detail every channel type that is allowed, and this will evolve depending on which channel types are supported by multiple implementations.

Each implementation should decide on its own policy for which upgraded channel types are available. The frequency at which we ship new channel types to the network is slow enough that we don't need a more complex protocol to thoroughly handle mismatches. The most likely outcome is that implementations will only allow the following transitions:

- upgrading to `anchor_outputs` from a pre-anchor channel
- upgrading to `simple_taproot` from an anchor or pre-anchor channel
- upgrading to `taproot_zero_fee_commitments` from any other channel type

This becomes more interesting once we've also integrated #1324, which adds the nonce fields to `interactive-tx` that are necessary for musig2.

Note that I opted for an odd TLV without a feature bit. It seems simpler to me to always opportunistically provide a `channel_type` in `splice_init` to try upgrading: nodes that don't support it will not send back a `channel_type` in `splice_ack`, and at that point the initiator can decide to either abort or move forward with the splice anyway without the `channel_type` upgrade (if it was splicing-in or out anyway, which is valuable regardless of the `channel_type` change).

One open question that I didn't address is that v3 transactions have stricter limits than v2 transaction: `max_accepted_htlcs` cannot exceed 114 for example. Do we want to simply implicitly trim those channel parameters on upgrade?