### PR TITLE
bolt04/09: add option_onion_messages_only_channels (feature 66/67)

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1785,7 +1785,10 @@ The writer:
 
 The reader:
 
-- SHOULD accept onion messages from peers without an established channel.
+- if it advertises `option_onion_messages_only_channels`:
+  - MUST NOT accept onion messages from peers without an established channel.
+- otherwise:
+  - SHOULD accept onion messages from peers without an established channel.
 - MAY rate-limit messages by dropping them.
 - MUST decrypt `onion_message_packet` using an empty `associated_data`, and `path_key`, as described in [Onion Decryption](04-onion-routing.md#onion-decryption) to extract an `onionmsg_tlv`.
 - If decryption fails, the result is not a valid `onionmsg_tlv`, or it contains unknown even types:
@@ -1826,6 +1829,19 @@ The reader:
 
 
 #### Rationale
+
+Accepting onion messages from channelless peers is the baseline: a node that
+advertises `option_onion_messages` is expected to accept onion messages from
+any connected peer.  This is a SHOULD rather than a MUST because acceptance
+is always best effort: a node may still drop messages due to rate-limiting.
+
+A node that wants to restrict acceptance to channel peers (e.g. to limit the
+DoS surface of free bandwidth/CPU for any node that can connect) advertises
+`option_onion_messages_only_channels` as an explicit opt-out.  A restrictive
+node should not silently drop these messages while advertising only the
+baseline: it has to advertise the bit, which makes the bit a reliable signal.
+A sender can therefore detect it and simply not attempt a relay it knows will
+fail, rather than sending a message that is silently dropped.
 
 Care must be taken that replies are only accepted using the exact
 reply_path given, otherwise probing is possible.  That means checking

--- a/09-features.md
+++ b/09-features.md
@@ -48,7 +48,7 @@ The Context column decodes as follows:
 | 28/29 | `option_dual_fund`                | Use v2 of channel open, enables dual funding              | IN       |                             | [BOLT #2](02-peer-protocol.md)                                        |
 | 34/35 | `option_quiesce`                  | Support for `stfu` message                                | IN       |                             | [BOLT #2][bolt02-quiescence]                                          |
 | 36/37 | `option_attribution_data`        | Can generate/relay attribution data and `fulfillment_payload` | IN9      |                             | [BOLT #4][bolt04-attribution-data], [successful payments][bolt04-successful-payments] |
-| 38/39 | `option_onion_messages`           | Can forward onion messages                                | IN       |                             | [BOLT #7](04-onion-routing.md#onion-messages)                         |
+| 38/39 | `option_onion_messages`           | Can forward onion messages                                | IN       |                             | [BOLT #4](04-onion-routing.md#onion-messages)                         |
 | 40/41 | `zero_fee_commitments`            | Zero-fee commitment and HTLC transactions                 | IN       | `option_channel_type`       | [BOLT #3][bolt03-shared-anchor]                                       |
 | 42/43 | `option_provide_storage`          | Can store other nodes' encrypted backup data              | IN       |                             | [BOLT #1](01-messaging.md#peer-storage)                               |
 | 44/45 | `option_channel_type`             | ASSUMED                                                   |          |                             |                                                                       |
@@ -57,6 +57,7 @@ The Context column decodes as follows:
 | 50/51 | `option_zeroconf`                 | Understands zeroconf channel types                        | INT      | `option_scid_alias`         | [BOLT #2][bolt02-channel-ready]                                       |
 | 60/61 | `option_simple_close`             | Simplified closing negotiation                            | IN       | `option_shutdown_anysegwit` | [BOLT #2][bolt02-simple-close]                                        |
 | 62/63 | `option_splice`                   | Allows replacing the funding transaction with a new one   | IN       |                             | [BOLT #2](02-peer-protocol.md#channel-splicing)                       |
+| 66/67 | `option_onion_messages_only_channels` | Only accepts onion messages from peers with a channel | IN       | `option_onion_messages`     | [BOLT #4](04-onion-routing.md#onion-messages)                         |
 
 ## Requirements
 


### PR DESCRIPTION
Some senders look up nodes advertising `option_onion_messages` and assume they can relay through them without holding a channel.  The spec was silent on accepting onion messages from channelless peers, so a node that restricts acceptance to channel peers was still compliant yet silently dropped those messages, with no feedback to the sender and no way for the sender to know in advance.

Make accepting onion messages from any connected peer the baseline: a node advertising `option_onion_messages` `SHOULD` accept them from channelless peers. This is a `SHOULD` rather than a `MUST` because acceptance is always best effort: a node may still drop messages due to rate-limiting.  Add `option_onion_messages_only_channels` (66/67), depending on `option_onion_messages`, as the explicit opt-out for a node that wants to restrict acceptance to channel peers (e.g. to limit the DoS surface of free bandwidth/CPU for any node that can connect). A restrictive node should not silently drop these messages while advertising only the baseline: it has to advertise the bit, which makes the pair a reliable signal.  Senders can detect it and simply not attempt a relay they know will fail, rather than hoping a compliant node happens to be lenient.