### PR TITLE
Clarify `simple_close` and `upfront_shutdown_script` compatibility

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -2182,9 +2182,10 @@ A receiving node:
     - MAY reply to a `shutdown` message with a `shutdown`
   - once there are no outstanding updates on the peer, UNLESS it has already sent a `shutdown`:
     - MUST reply to a `shutdown` message with a `shutdown`
-  - if both nodes advertised the `option_upfront_shutdown_script` feature, and the receiving node received a non-zero-length `shutdown_scriptpubkey` in `open_channel` or `accept_channel`, and that `shutdown_scriptpubkey` is not equal to `scriptpubkey`:
-    - MAY send a `warning`.
-    - MUST fail the connection.
+  - if both nodes advertised the `option_upfront_shutdown_script` feature, and the receiving node received a non-zero-length `shutdown_scriptpubkey` in `open_channel` or `accept_channel`, and that `shutdown_scriptpubkey` is not equal to `scriptpubkey`
+    - if not both nodes advertised `option_simple_close` and the `shutdown_scriptpubkey` is `OP_RETURN`:
+        - MAY send a `warning`.
+        - MUST fail the connection.
 
 #### Rationale
 


### PR DESCRIPTION
The `option_upfront_shutdown_script` feature mandates that a node fails the connection if the counterparty provides a shutdown script that doesn't match what was previously negotiated during channel open.

However, `option_simple_close` allows the counterparty to change its shutdown script to a 0-value `OP_RETURN` if it doesn't deem its output economical to still meet the dust threshold. Here we simply clarify that both are compatible, i.e., the `OP_RETURN` special case for `option_simple_close` shouldn't be rejected even if `option_upfront_shutdown_script` was negotiated.