### PR TITLE
BOLT 4: clarify final onion payload must always contain total_msat

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -337,8 +337,8 @@ The reader:
         - incoming `amount_msat` - `fee` < `amt_to_forward` (where `fee` is the advertised fee as described in [BOLT #7](07-routing-gossip.md#htlc-fees))
         - `cltv_expiry` - `cltv_expiry_delta` < `outgoing_cltv_value`
   - If it is the final node:
-    - MUST treat `total_msat` as if it were equal to `amt_to_forward` if it is not present.
     - MUST return an error if:
+      - `total_msat` is not present
       - incoming `amount_msat` < `amt_to_forward`.
       - incoming `cltv_expiry` < `outgoing_cltv_value`.
       - incoming `cltv_expiry` < `current_block_height` + `min_final_cltv_expiry_delta`.


### PR DESCRIPTION
Now that [`option_payment_secret` is assumed](https://github.com/lightning/bolts/commit/872c6eca9c813a543ec8f0f79dcffc5df03f4bc3), the `total_msat` field must always be present for final onions.

Either the `payment_data` TLV or the `total_amount_msat` TLV must be present, which implies `total_msat` being present.